### PR TITLE
Add *.bak files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .ccls-cache/
 .cache/
 build/
+*.bak
+


### PR DESCRIPTION
Some text editors leaves *.bak files on disk after saving. This change keeps those files from showing up in commits.