### PR TITLE
move Cmakelists, prepare_build to project root, use <project_root>/build as default build dir, add possibility to run prepare_build on existing dir, moved build instruction to main README.md

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,33 +12,32 @@ else()
   set(PROTOC ${PROJECT_BINARY_DIR}/vcpkg/installed/x64-linux/tools/protobuf/protoc)
 endif()
 
-# Calls the protoc compiler using the arguments specific to this project.
+# Calls the protoc compiler using the arguments specific to this project
 # protobuf_generate_cpp is not flexible enough for our needs.
 add_custom_command(
   OUTPUT ${PROJECT_BINARY_DIR}/gen/content_analysis/sdk/analysis.pb.cc
   COMMAND
     ${PROTOC}
     --cpp_out=${PROJECT_BINARY_DIR}/gen
-    --proto_path=${PROJECT_SOURCE_DIR}/../proto
-    ${PROJECT_SOURCE_DIR}/../proto/content_analysis/sdk/analysis.proto
-  DEPENDS ../proto/content_analysis/sdk/analysis.proto
+    --proto_path=${PROJECT_SOURCE_DIR}/proto
+    ${PROJECT_SOURCE_DIR}/proto/content_analysis/sdk/analysis.proto
+  DEPENDS ./proto/content_analysis/sdk/analysis.proto
   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
 )
-
-# Define protos target. Compile this target exclusively by calling:
-# `cmake --build <build_dir> --target protos`
-add_custom_target(protos ALL DEPENDS ${PROJECT_BINARY_DIR}/gen/content_analysis/sdk/analysis.pb.cc)
+# Define proto target. Compile this target exclusively by calling:
+# `cmake --build <build_dir> --target proto`
+add_custom_target(proto ALL DEPENDS ${PROJECT_BINARY_DIR}/gen/content_analysis/sdk/analysis.pb.cc)
 
 # The include directory contains the header files needed by the demo code.
 # The gen directory contains generated protobuf headers describing the request
 # and response objects used to communicate with Google Chrome.
 set(AGENT_INCLUDES
-  "${PROJECT_SOURCE_DIR}/../agent/include"
-  "${PROJECT_BINARY_DIR}/gen"
+  ./agent/include
+  ${PROJECT_BINARY_DIR}/gen
 )
 set(BROWSER_INCLUDES
-  "${PROJECT_SOURCE_DIR}/../browser/include"
-  "${PROJECT_BINARY_DIR}/gen"
+  ./browser/include
+  ${PROJECT_BINARY_DIR}/gen
 )
 
 # The SDK contains platform specific code for each of the supported platforms.
@@ -46,17 +45,17 @@ set(BROWSER_INCLUDES
 # platform being built.
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set(PLATFORM_AGENT_CODE
-    ../agent/src/agent_win.cc
-    ../agent/src/agent_win.h
-    ../agent/src/session_win.cc
-    ../agent/src/session_win.h
+    ./agent/src/agent_win.cc
+    ./agent/src/agent_win.h
+    ./agent/src/session_win.cc
+    ./agent/src/session_win.h
   )
 else()
   set(PLATFORM_AGENT_CODE
-    ../agent/src/agent_posix.cc
-    ../agent/src/agent_posix.h
-    ../agent/src/session_posix.cc
-    ../agent/src/session_posix.h
+    ./agent/src/agent_posix.cc
+    ./agent/src/agent_posix.h
+    ./agent/src/session_posix.cc
+    ./agent/src/session_posix.h
   )
 endif()
 
@@ -65,13 +64,13 @@ endif()
 # platform being built.
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set(PLATFORM_BROWSER_CODE
-    ../browser/src/client_win.cc
-    ../browser/src/client_win.h
+    ./browser/src/client_win.cc
+    ./browser/src/client_win.h
   )
 else()
   set(PLATFORM_BROWSER_CODE
-    ../browser/src/client_posix.cc
-    ../browser/src/client_posix.h
+    ./browser/src/client_posix.cc
+    ./browser/src/client_posix.h
   )
 endif()
 
@@ -83,11 +82,11 @@ find_package(Protobuf CONFIG REQUIRED)
 # into the agent in order to listen for and process content analysis requests
 # from Google Chrome.
 add_library(cac_agent
-  ../agent/include/content_analysis/sdk/analysis_agent.h
-  ../agent/src/agent_base.cc
-  ../agent/src/agent_base.h
-  ../agent/src/session_base.cc
-  ../agent/src/session_base.h
+  ./agent/include/content_analysis/sdk/analysis_agent.h
+  ./agent/src/agent_base.cc
+  ./agent/src/agent_base.h
+  ./agent/src/session_base.cc
+  ./agent/src/session_base.h
   ${PLATFORM_AGENT_CODE}
   ${PROJECT_BINARY_DIR}/gen/content_analysis/sdk/analysis.pb.cc
 )
@@ -96,9 +95,9 @@ target_include_directories(cac_agent PRIVATE ${AGENT_INCLUDES})
 # Builds the content analysis connector browser linker library.  This library is linked
 # into the client in order to send content analysis requests to the agent.
 add_library(cac_browser
-  ../browser/include/content_analysis/sdk/analysis_client.h
-  ../browser/src/client_base.cc
-  ../browser/src/client_base.h
+  ./browser/include/content_analysis/sdk/analysis_client.h
+  ./browser/src/client_base.cc
+  ./browser/src/client_base.h
   ${PLATFORM_BROWSER_CODE}
   ${PROJECT_BINARY_DIR}/gen/content_analysis/sdk/analysis.pb.cc
 )
@@ -106,11 +105,11 @@ target_include_directories(cac_browser PRIVATE ${BROWSER_INCLUDES})
 target_link_libraries(cac_browser PUBLIC protobuf::libprotoc protobuf::libprotobuf protobuf::libprotobuf-lite)
 
 # The demo agent executable.
-add_executable(agent agent.cc)
+add_executable(agent ./demo/agent.cc)
 target_include_directories(agent PRIVATE ${AGENT_INCLUDES})
 target_link_libraries(agent PRIVATE cac_agent)
 
 # The demo client executable.
-add_executable(browser client.cc)
+add_executable(browser ./demo/client.cc)
 target_include_directories(browser PRIVATE ${BROWSER_INCLUDES})
 target_link_libraries(browser PRIVATE cac_browser)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ else()
   set(PROTOC ${PROJECT_BINARY_DIR}/vcpkg/installed/x64-linux/tools/protobuf/protoc)
 endif()
 
-# Calls the protoc compiler using the arguments specific to this project
+# Calls the protoc compiler using the arguments specific to this project.
 # protobuf_generate_cpp is not flexible enough for our needs.
 add_custom_command(
   OUTPUT ${PROJECT_BINARY_DIR}/gen/content_analysis/sdk/analysis.pb.cc

--- a/README.md
+++ b/README.md
@@ -21,3 +21,50 @@ the `browser` subdirectory.
 The Protocol Buffer serialization format is used to serialize messages between the
 browser and the agent. The protobuf definitions used can be found in the `proto`
 subdirectory.
+
+## Google Protocol Buffers
+
+This SDK depends on Google Protocol Buffers version 3.18 or later.  It may be
+installed from Google's [download page](https://developers.google.com/protocol-buffers/docs/downloads#release-packages)
+for your developement platform.  It may also be installed using a package
+manager.
+
+The included prepare_build scripts use the Microsoft [vcpkg](https://github.com/microsoft/vcpkg)
+package manager to install protobuf.  vcpkg is available on all supported
+platforms.
+
+## Build
+
+### Pre-requisites
+
+The following must be installed on the computer before building the demo:
+
+- [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) version 2.33 or later.
+- [cmake](https://cmake.org/install/) version 3.23 or later.
+- A C++ compiler toolchain for your platform.
+- On linux, the `realpath` shell tool, available in the `coreutils` package.
+  In Debian-based distributions use `sudo apt intall coreutils`.
+  In Red Hat distributions use `sudo yum install coreutils`.
+
+### Running prepare_build
+
+First get things ready by installing required dependencies:
+```
+$SDK_DIR/prepare_build <build-dir>
+```
+where `<build-dir>` is the path to a directory where the demo will be built.
+By default, if no argument is provided, a directory named `build` will be
+created in the project root. Any output within the `build/` directory will
+be ignored by version control.
+
+`prepare_build` performs the following steps:
+1. Downloads the vcpkg package manager.
+2. Downloads and builds the Google Protocol Buffers library.
+3. Generates the headers and sources for the content analysis protobuf message.
+4. Creates build files for your specific platform.
+
+### Cmake Targets
+
+To build the demo run the command `cmake --build <build-dir>`.
+
+To build the protocol buffer targets run the command `cmake --build <build-dir> --target proto`

--- a/demo/README.md
+++ b/demo/README.md
@@ -3,45 +3,4 @@
 This directory holds the Google Chrome Content Analysis Connector Agent SDK Demo.
 It contains an example of how to use the SDK.
 
-## Pre-requisites
-
-The following must be installed on the computer before building the demo:
-
-- [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) version 2.33 or later.
-- [cmake](https://cmake.org/install/) version 3.23 or later.
-- A C++ compiler toolchain for your platform.
-- On linux, the `realpath` shell tool, available in the `coreutils` package.
-  In Debian-based distributions use `sudo apt intall coreutils`.
-  In Red Hat distributions use `sudo yum install coreutils`.
-
-### Google Protocol Buffers
-
-This SDK depends on Google Protocol Buffers version 3.18 or later.  It may be
-installed from Google's [download page](https://developers.google.com/protocol-buffers/docs/downloads#release-packages)
-for your developement platform.  It may also be installed using a package
-manager.
-
-This demo uses the Microsoft [vcpkg](https://github.com/microsoft/vcpkg)
-package manager to install protobuf.  vcpkg is available on all supported
-platforms.
-
-## Build
-
-First get things ready by installing required dependencies:
-```
-$SDK_DIR/demo/prepare_build <build-dir>
-```
-where `<build-dir>` is the path to a directory where the demo will be built.
-This directory must not already exist. If building within the source tree, it is
-recommended to use a directory named `build` (eg: `/demo/build`). Any output
-within the `build/` directory will be ignored by version control.
-
-`prepare_build` performs the following steps:
-1. Downloads the vcpkg package manager.
-2. Downloads and builds the Google Protocol Buffers library.
-3. Generates the headers and sources for the content analysis protobuf message.
-4. Creates build files for your specific platform.
-
-To build the demo run the command `cmake --build <build-dir>`.
-
-To build the protocol buffer targets run the command `cmake --build <build-dir> --target protos`
+Build instructions are available in the main project `README.md`.

--- a/prepare_build
+++ b/prepare_build
@@ -5,8 +5,9 @@
 
 # This script is meant to be run once to setup the example demo agent.
 # Run it with one command line argument: the path to a directory where the
-# demo agent will be built.  This should be a directory outside the SDK
-# directory tree.  This directory must not already exist.
+# demo agent will be built. This should be a directory outside the SDK
+# directory tree. By default, if no directory is supplied, a directory
+# named `build` in the project root will be used.
 #
 # Once the build is prepared, the demo binary is build using the command
 # `cmake --build <build-dir>`, where <build-dir> is the same argument given
@@ -14,21 +15,19 @@
 
 set -euo pipefail
 
-export BUILD_DIR=$(realpath $1)
-export ROOT_DIR=$(realpath $(dirname $0)/..)
+export ROOT_DIR=$(realpath $(dirname $0))
 export DEMO_DIR=$(realpath $ROOT_DIR/demo)
 export PROTO_DIR=$(realpath  $ROOT_DIR/proto)
+if [ -z "$1" ]; then
+  export BUILD_DIR=$(realpath $ROOT_DIR/build)
+else
+  export BUILD_DIR=$(realpath $1)
+fi
 
 echo Root dir:   $ROOT_DIR
 echo Build dir:  $BUILD_DIR
 echo Demo dir:   $DEMO_DIR
 echo Proto dir:  $PROTO_DIR
-
-test -d $BUILD_DIR && (
-  echo ""
-  echo "  *** $BUILD_DIR must not exist"
-  return 1 2>/dev/null || exit 1
-)
 
 # Prepare build directory
 mkdir -p $BUILD_DIR
@@ -41,10 +40,11 @@ cd $BUILD_DIR
 test -d vcpkg || (
   git clone https://github.com/microsoft/vcpkg
   ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
-  ./vcpkg/vcpkg install protobuf
 )
+# Install any packages we want from vcpkg.
+./vcpkg/vcpkg install protobuf
 
 # Generate the build files.
 export CMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake
-cmake $DEMO_DIR
+cmake $ROOT_DIR
 

--- a/prepare_build
+++ b/prepare_build
@@ -18,11 +18,8 @@ set -euo pipefail
 export ROOT_DIR=$(realpath $(dirname $0))
 export DEMO_DIR=$(realpath $ROOT_DIR/demo)
 export PROTO_DIR=$(realpath  $ROOT_DIR/proto)
-if [ -z "$1" ]; then
-  export BUILD_DIR=$(realpath $ROOT_DIR/build)
-else
-  export BUILD_DIR=$(realpath $1)
-fi
+# Defaults to $ROOT_DIR/build if no argument is provided.
+export BUILD_DIR=$(realpath ${1:-$ROOT_DIR/build})
 
 echo Root dir:   $ROOT_DIR
 echo Build dir:  $BUILD_DIR

--- a/prepare_build
+++ b/prepare_build
@@ -9,7 +9,7 @@
 # directory tree. By default, if no directory is supplied, a directory
 # named `build` in the project root will be used.
 #
-# Once the build is prepared, the demo binary is build using the command
+# Once the build is prepared, the demo binary is built using the command
 # `cmake --build <build-dir>`, where <build-dir> is the same argument given
 # to this script.
 

--- a/prepare_build.bat
+++ b/prepare_build.bat
@@ -10,13 +10,15 @@ REM demo agent will be built. This should be a directory outside the SDK
 REM directory tree. By default, if no directory is supplied, a directory
 REM named `build` in the project root will be used.
 REM
-REM Once the build is prepared, the demo binary is build using the command
+REM Once the build is prepared, the demo binary is built using the command
 REM `cmake --build <build-dir>`, where <build-dir> is the same argument given
 REM to this script.
 
 set ROOT_DIR=%~dp0
 call :ABSPATH "%ROOT_DIR%\demo" DEMO_DIR
 call :ABSPATH "%ROOT_DIR%\proto" PROTO_DIR
+
+REM BUILD_DIR defaults to $ROOT_DIR/build if no argument is provided.
 IF "%1" == "" (
   call :ABSPATH "%ROOT_DIR%\build" BUILD_DIR
 ) ELSE (

--- a/proto/content_analysis/sdk/analysis.proto
+++ b/proto/content_analysis/sdk/analysis.proto
@@ -16,7 +16,7 @@ message Handshake {
     SUCCESS = 1;
     FAILURE = 2;
   }
-  required Status status = 1; 
+  optional Status status = 1; 
 }
 
 // An Acknowledgment is sent from the browser to the agent
@@ -27,7 +27,7 @@ message Acknowledgement {
     SUCCESS = 1;
     FAILURE = 2;
   }
-  required Status status = 1;
+  optional Status status = 1;
 }
 
 // The values in this enum can be extended in future versions of Chrome to


### PR DESCRIPTION
fix paths in CMakeLists to be relative to project root

Change prepare_build paths to be relative to project root. Use build as default build dir

update comments with default build arg

in prepare_build, remove requirement for build directory to not exist (allow running script on existing build dir)

move build instructions to main README