### PR TITLE
refactor calls to SerializeToString into SerializeAsString

### DIFF
--- a/agent/src/session_win.cc
+++ b/agent/src/session_win.cc
@@ -42,11 +42,7 @@ int SessionWin::Close() {
 }
 
 int SessionWin::Send() {
-  std::string response_str;
-  if (!response()->SerializeToString(&response_str))
-    return -1;
-
-  if (!WriteMessageToPipe(hPipe_, response_str))
+  if (!WriteMessageToPipe(hPipe_, response()->SerializeAsString()))
     return -1;
 
   std::vector<char> buffer = ReadNextMessageFromPipe(hPipe_);

--- a/browser/src/client_win.cc
+++ b/browser/src/client_win.cc
@@ -55,22 +55,18 @@ DWORD ClientWin::ConnectToPipe(HANDLE* handle) {
 
 int ClientWin::Send(const ContentAnalysisRequest& request,
                     ContentAnalysisResponse* response) {
-  std::string request_str;
-  if (!request.SerializeToString(&request_str)) {
-    return -1;
-  }
-
   HANDLE handle;
   if (ConnectToPipe(&handle) != ERROR_SUCCESS) {
     return -1;
   }
 
-  bool success = false;
-
   Handshake handshake;
   handshake.set_content_analysis_requested(true);
+  
+  bool success = false;
+
   if (WriteMessageToPipe(handle, handshake.SerializeAsString())) {
-    if (WriteMessageToPipe(handle, request_str)) {
+    if (WriteMessageToPipe(handle, request.SerializeAsString())) {
       Acknowledgement acknowledgement;
       std::vector<char> buffer = ReadNextMessageFromPipe(handle);
       if (response->ParseFromArray(buffer.data(), buffer.size())) {


### PR DESCRIPTION
Removes the need for temporary variables to hold strings that are used exactly once.

SendMessageToPipe correctly handles empty strings, which means that we can use SerializeAsString, which returns an empty string on error.