### PR TITLE
Make sure library compiles on Windows if UNICODE or _UNICODE is defined

### DIFF
--- a/agent/src/agent_win.cc
+++ b/agent/src/agent_win.cc
@@ -57,7 +57,7 @@ int AgentWin::Stop() {
 DWORD AgentWin::CreatePipe(HANDLE* handle) {
   DWORD err = ERROR_SUCCESS;
 
-  *handle = CreateNamedPipe(pipename_.c_str(),
+  *handle = CreateNamedPipeA(pipename_.c_str(),
     PIPE_ACCESS_DUPLEX, PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT |
         PIPE_REJECT_REMOTE_CLIENTS,
     PIPE_UNLIMITED_INSTANCES, kBufferSize, kBufferSize, 0, nullptr);

--- a/browser/src/client_win.cc
+++ b/browser/src/client_win.cc
@@ -25,14 +25,14 @@ ClientWin::ClientWin(const Uri& uri) : ClientBase(uri) {
 DWORD ClientWin::ConnectToPipe(HANDLE* handle) {
   HANDLE h = INVALID_HANDLE_VALUE;
   while (h == INVALID_HANDLE_VALUE) {
-    h = CreateFile(pipename_.c_str(), GENERIC_READ | GENERIC_WRITE, 0,
+    h = CreateFileA(pipename_.c_str(), GENERIC_READ | GENERIC_WRITE, 0,
         nullptr, OPEN_EXISTING, 0, nullptr);
     if (h == INVALID_HANDLE_VALUE) {
       if (GetLastError() != ERROR_PIPE_BUSY) {
         break;
       }
 
-      if (!WaitNamedPipe(pipename_.c_str(), NMPWAIT_USE_DEFAULT_WAIT)) {
+      if (!WaitNamedPipeA(pipename_.c_str(), NMPWAIT_USE_DEFAULT_WAIT)) {
         break;
       }
     }


### PR DESCRIPTION
win32 APIs that take string arguments can take either a char* or a wchar_t*.  The API names end with A or W respectively.  If no suffix is given, then the preprocessor defines UNICODE and _UNICODE control which ones map to the non-suffixed names (i.e. whether CreateFile() maps to CreateFileA() or CreateFileW()).

Since this code uses char*, change all affected win32 APIs to use the explicitly suffixed names so that UNICODE and _UNICODE don't affect the code.