### PR TITLE
Support OS user specific agents

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,10 +53,12 @@ add_custom_target(proto ALL DEPENDS ${PROJECT_BINARY_DIR}/gen/content_analysis/s
 # and response objects used to communicate with Google Chrome.
 set(AGENT_INCLUDES
   ./agent/include
+  .
   ${PROJECT_BINARY_DIR}/gen
 )
 set(BROWSER_INCLUDES
   ./browser/include
+  .
   ${PROJECT_BINARY_DIR}/gen
 )
 
@@ -69,6 +71,8 @@ if(WIN)
     ./agent/src/agent_win.h
     ./agent/src/session_win.cc
     ./agent/src/session_win.h
+    ./common/utils_win.cc
+    ./common/utils_win.h
   )
   set(PLATFORM_QUEUED_AGENT_DEMO_CODE
     ./demo/queued_agent_win.cc
@@ -99,6 +103,8 @@ if(WIN)
   set(PLATFORM_BROWSER_CODE
     ./browser/src/client_win.cc
     ./browser/src/client_win.h
+    ./common/utils_win.cc
+    ./common/utils_win.h
   )
 elseif(MAC)
   set(PLATFORM_BROWSER_CODE

--- a/agent/include/content_analysis/sdk/analysis_agent.h
+++ b/agent/include/content_analysis/sdk/analysis_agent.h
@@ -101,16 +101,26 @@ class Session {
 // See the demo directory for an example of how to use this class.
 class Agent {
  public:
-  // A unique identifier for Google Chrome's content analysis partner.
-  using Uri = std::string;
+  // Configuration options where creating an agent.  `name` is used to create
+  // a channel between the agent and Google Chrome.  
+  struct Config {
+    // Used to create a channel between the agent and Google Chrome.  Both must
+    // use the same name to properly rendezvous with each other.  The channel
+    // is platform specific.
+    std::string name;
+
+    // Set to true if there is a different agent instance per OS user.  Defaults
+    // to false.
+    bool user_specific = false;
+  };
 
   // Returns a new agent instance and calls Start().
-  static std::unique_ptr<Agent> Create(const Uri& uri);
+  static std::unique_ptr<Agent> Create(Config config);
 
   virtual ~Agent() = default;
 
-  // Returns the URI of the agent.
-  virtual const Uri& GetUri() const = 0;
+  // Returns the configuration parameters of the agent.
+  virtual const Config& GetConfig() const = 0;
 
   // Returns a new content analysis session from Google Chrome.
   // The session's associated request and response have already been

--- a/agent/src/agent_base.cc
+++ b/agent/src/agent_base.cc
@@ -2,15 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <utility>
+
 #include "agent_base.h"
 
 namespace content_analysis {
 namespace sdk {
 
-AgentBase::AgentBase(const Uri& uri) : uri_(uri) {}
+AgentBase::AgentBase(Config config) : config_(std::move(config)) {}
 
-const Agent::Uri& AgentBase::GetUri() const {
-  return uri_;
+const Agent::Config& AgentBase::GetConfig() const {
+  return config_;
 }
 
 int AgentBase::Stop() {

--- a/agent/src/agent_base.h
+++ b/agent/src/agent_base.h
@@ -14,14 +14,16 @@ namespace sdk {
 class AgentBase : public Agent {
  public:
   // Agent:
-  const Uri& GetUri() const override;
+  const Config& GetConfig() const override;
   int Stop() override;
 
  protected:
-  AgentBase(const Uri& uri);
+  AgentBase(Config config);
+
+  const Config& configuration() const { return config_; }
 
  private:
-  Uri uri_;
+  Config config_;
 };
 
 }  // namespace sdk

--- a/agent/src/agent_mac.cc
+++ b/agent/src/agent_mac.cc
@@ -9,11 +9,11 @@ namespace content_analysis {
 namespace sdk {
 
 // static
-std::unique_ptr<Agent> Agent::Create(const Uri& uri) {
-  return std::make_unique<AgentMac>(uri);
+std::unique_ptr<Agent> Agent::Create(Config config) {
+  return std::make_unique<AgentMac>(std::move(config));
 }
 
-AgentMac::AgentMac(const Uri& uri) : AgentBase(uri) {}
+AgentMac::AgentMac(Config config) : AgentBase(std::move(config)) {}
 
 std::unique_ptr<Session> AgentMac::GetNextSession() {
   return std::make_unique<SessionMac>();

--- a/agent/src/agent_mac.h
+++ b/agent/src/agent_mac.h
@@ -13,7 +13,7 @@ namespace sdk {
 // Agent implementaton for macos.
 class AgentMac : public AgentBase {
  public:
-  AgentMac(const Uri& uri);
+  AgentMac(Config config);
 
   std::unique_ptr<Session> GetNextSession() override;
 

--- a/agent/src/agent_posix.cc
+++ b/agent/src/agent_posix.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <utility>
+
 #include "agent_posix.h"
 #include "session_posix.h"
 
@@ -9,11 +11,11 @@ namespace content_analysis {
 namespace sdk {
 
 // static
-std::unique_ptr<Agent> Agent::Create(const Uri& uri) {
-  return std::make_unique<AgentPosix>(uri);
+std::unique_ptr<Agent> Agent::Create(Config config) {
+  return std::make_unique<AgentPosix>(std::move(config));
 }
 
-AgentPosix::AgentPosix(const Uri& uri) : AgentBase(uri) {}
+AgentPosix::AgentPosix(Config config) : AgentBase(std::move(config)) {}
 
 std::unique_ptr<Session> AgentPosix::GetNextSession() {
   return std::make_unique<SessionPosix>();

--- a/agent/src/agent_posix.h
+++ b/agent/src/agent_posix.h
@@ -13,7 +13,7 @@ namespace sdk {
 // Agent implementaton for linux.
 class AgentPosix : public AgentBase {
  public:
-  AgentPosix(const Uri& uri);
+  AgentPosix(Config config);
 
   std::unique_ptr<Session> GetNextSession() override;
 

--- a/agent/src/agent_win.cc
+++ b/agent/src/agent_win.cc
@@ -2,6 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <utility>
+#include <vector>
+
+#include <windows.h>
+#include <sddl.h>
+
+#include "common/utils_win.h"
+
 #include "agent_win.h"
 #include "session_win.h"
 
@@ -11,12 +19,17 @@ namespace sdk {
 const DWORD kBufferSize = 4096;
 
 // static
-std::unique_ptr<Agent> Agent::Create(const Uri& uri) {
-  return std::make_unique<AgentWin>(uri);
+std::unique_ptr<Agent> Agent::Create(Config config) {
+  return std::make_unique<AgentWin>(std::move(config));
 }
 
-AgentWin::AgentWin(const Uri& uri) : AgentBase(uri) {
-  pipename_ = "\\\\.\\pipe\\" + uri;
+AgentWin::AgentWin(Config config) : AgentBase(std::move(config)) {
+  std::string pipename =
+      internal::GetPipName(configuration().name, configuration().user_specific);
+  if (pipename.empty())
+    return;
+
+  pipename_ = pipename;
   CreatePipe(&hPipe_);
 }
 

--- a/agent/src/agent_win.cc
+++ b/agent/src/agent_win.cc
@@ -25,7 +25,7 @@ std::unique_ptr<Agent> Agent::Create(Config config) {
 
 AgentWin::AgentWin(Config config) : AgentBase(std::move(config)) {
   std::string pipename =
-      internal::GetPipName(configuration().name, configuration().user_specific);
+      internal::GetPipeName(configuration().name, configuration().user_specific);
   if (pipename.empty())
     return;
 

--- a/agent/src/agent_win.h
+++ b/agent/src/agent_win.h
@@ -17,7 +17,7 @@ namespace sdk {
 // Agent implementaton for Windows.
 class AgentWin : public AgentBase {
  public:
-  AgentWin(const Uri& uri);
+  AgentWin(Config config);
   ~AgentWin() override;
 
   // Agent:

--- a/browser/include/content_analysis/sdk/analysis_client.h
+++ b/browser/include/content_analysis/sdk/analysis_client.h
@@ -30,16 +30,26 @@ namespace sdk {
 // See the demo directory for an example of how to use this class.
 class Client {
  public:
-  // A unique identifier for Google Chrome's content analysis partner.
-  using Uri = std::string;
+   // Configuration options where creating an agent.  `name` is used to create
+   // a channel between the agent and Google Chrome.  
+   struct Config {
+     // Used to create a channel between the agent and Google Chrome.  Both must
+     // use the same name to properly rendezvous with each other.  The channel
+     // is platform specific.
+     std::string name;
+
+     // Set to true if there is a different agent instance per OS user.  Defaults
+     // to false.
+     bool user_specific = false;
+   };
 
   // Returns a new client instance and calls Start().
-  static std::unique_ptr<Client> Create(const Uri& uri);
+  static std::unique_ptr<Client> Create(Config config);
 
   virtual ~Client() = default;
 
-  // Returns the URI of the partner.
-  virtual const Uri& GetUri() const = 0;
+  // Returns the configuration parameters of the client.
+  virtual const Config& GetConfig() const = 0;
 
   // Sets an analysis request to the agent and waits for a response.
   virtual int Send(const ContentAnalysisRequest& request,

--- a/browser/src/client_base.cc
+++ b/browser/src/client_base.cc
@@ -7,10 +7,10 @@
 namespace content_analysis {
 namespace sdk {
 
-ClientBase::ClientBase(const Uri& uri) : uri_(uri) {}
+ClientBase::ClientBase(Config config) : config_(config) {}
 
-const Client::Uri& ClientBase::GetUri() const {
-  return uri_;
+const Client::Config& ClientBase::GetConfig() const {
+  return config_;
 }
 
 }  // namespace sdk

--- a/browser/src/client_base.h
+++ b/browser/src/client_base.h
@@ -14,13 +14,15 @@ namespace sdk {
 class ClientBase : public Client {
  public:
   // Client:
-  const Uri& GetUri() const override;
+  const Config& GetConfig() const override;
 
  protected:
-  ClientBase(const Uri& uri);
+  ClientBase(Config config);
 
- private:
-  Uri uri_;
+  const Config& configuration() const { return config_; }
+
+private:
+  Config config_;
 };
 
 }  // namespace sdk

--- a/browser/src/client_mac.cc
+++ b/browser/src/client_mac.cc
@@ -2,17 +2,19 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <utility>
+
 #include "client_mac.h"
 
 namespace content_analysis {
 namespace sdk {
 
 // static
-std::unique_ptr<Client> Client::Create(const Uri& uri) {
-  return std::make_unique<ClientMac>(uri);
+std::unique_ptr<Client> Client::Create(Config config) {
+  return std::make_unique<ClientMac>(std::move(config));
 }
 
-ClientMac::ClientMac(const Uri& uri) : ClientBase(uri) {}
+ClientMac::ClientMac(Config config) : ClientBase(std::move(config)) {}
 
 int ClientMac::Send(const ContentAnalysisRequest& request,
                     ContentAnalysisResponse* response) {

--- a/browser/src/client_mac.h
+++ b/browser/src/client_mac.h
@@ -13,7 +13,7 @@ namespace sdk {
 // Client implementaton for Mac.
 class ClientMac : public ClientBase {
  public:
-  ClientMac(const Uri& uri);
+  ClientMac(Config config);
 
   // Client:
   int Send(const ContentAnalysisRequest& request,

--- a/browser/src/client_posix.cc
+++ b/browser/src/client_posix.cc
@@ -2,17 +2,19 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <utility>
+
 #include "client_posix.h"
 
 namespace content_analysis {
 namespace sdk {
 
 // static
-std::unique_ptr<Client> Client::Create(const Uri& uri) {
-  return std::make_unique<ClientPosix>(uri);
+std::unique_ptr<Client> Client::Create(Config config) {
+  return std::make_unique<ClientPosix>(std::move(config));
 }
 
-ClientPosix::ClientPosix(const Uri& uri) : ClientBase(uri) {}
+ClientPosix::ClientPosix(Config config) : ClientBase(std::move(config)) {}
 
 int ClientPosix::Send(const ContentAnalysisRequest& request,
                     ContentAnalysisResponse* response) {

--- a/browser/src/client_posix.h
+++ b/browser/src/client_posix.h
@@ -13,7 +13,7 @@ namespace sdk {
 // Client implementaton for Posix.
 class ClientPosix : public ClientBase {
  public:
-  ClientPosix(const Uri& uri);
+  ClientPosix(Config config);
 
   // Client:
   int Send(const ContentAnalysisRequest& request,

--- a/browser/src/client_win.cc
+++ b/browser/src/client_win.cc
@@ -23,7 +23,7 @@ std::unique_ptr<Client> Client::Create(Config config) {
 
 ClientWin::ClientWin(Config config) : ClientBase(std::move(config)) {
   std::string pipename =
-    internal::GetPipName(configuration().name, configuration().user_specific);
+    internal::GetPipeName(configuration().name, configuration().user_specific);
   if (pipename.empty())
     return;
 

--- a/browser/src/client_win.cc
+++ b/browser/src/client_win.cc
@@ -4,7 +4,10 @@
 
 #include <windows.h>
 
+#include <utility>
 #include <vector>
+
+#include "common/utils_win.h"
 
 #include "client_win.h"
 
@@ -14,12 +17,17 @@ namespace sdk {
 const DWORD kBufferSize = 4096;
 
 // static
-std::unique_ptr<Client> Client::Create(const Uri& uri) {
-  return std::make_unique<ClientWin>(uri);
+std::unique_ptr<Client> Client::Create(Config config) {
+  return std::make_unique<ClientWin>(std::move(config));
 }
 
-ClientWin::ClientWin(const Uri& uri) : ClientBase(uri) {
-  pipename_ = "\\\\.\\pipe\\" + uri;
+ClientWin::ClientWin(Config config) : ClientBase(std::move(config)) {
+  std::string pipename =
+    internal::GetPipName(configuration().name, configuration().user_specific);
+  if (pipename.empty())
+    return;
+
+  pipename_ = pipename;
 }
 
 DWORD ClientWin::ConnectToPipe(HANDLE* handle) {

--- a/browser/src/client_win.h
+++ b/browser/src/client_win.h
@@ -15,7 +15,7 @@ namespace sdk {
 // Client implementaton for Windows.
 class ClientWin : public ClientBase {
  public:
-  ClientWin(const Uri& uri);
+  ClientWin(Config config);
 
   // Client:
   int Send(const ContentAnalysisRequest& request,

--- a/common/utils_win.cc
+++ b/common/utils_win.cc
@@ -47,12 +47,11 @@ std::string GetUserSID() {
 std::string GetPipeName(const std::string& base, bool user_specific) {
   std::string pipename = "\\\\.\\pipe\\" + base;
   if (user_specific) {
-    pipename += ".";
     std::string sid = GetUserSID();
     if (sid.empty())
       return std::string();
 
-    pipename += +"." + sid;
+    pipename += "." + sid;
   }
 
   return pipename;

--- a/common/utils_win.cc
+++ b/common/utils_win.cc
@@ -1,0 +1,63 @@
+// Copyright 2022 The Chromium Authors.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <vector>
+
+#include <windows.h>
+#include <sddl.h>
+
+#include "utils_win.h"
+
+namespace content_analysis {
+namespace sdk {
+namespace internal {
+
+std::string GetUserSID() {
+  std::string sid;
+
+  HANDLE handle;
+  if (!OpenThreadToken(GetCurrentThread(), TOKEN_QUERY, TRUE, &handle) &&
+    !OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &handle)) {
+    return std::string();
+  }
+
+  DWORD length = 0;
+  std::vector<char> buffer;
+  if (!GetTokenInformation(handle, TokenUser, nullptr, 0, &length)) {
+    DWORD err = GetLastError();
+    if (err == ERROR_INSUFFICIENT_BUFFER) {
+      buffer.resize(length);
+    }
+  }
+  if (GetTokenInformation(handle, TokenUser, buffer.data(), buffer.size(),
+    &length)) {
+    TOKEN_USER* info = reinterpret_cast<TOKEN_USER*>(buffer.data());
+    char* sid_string;
+    if (ConvertSidToStringSidA(info->User.Sid, &sid_string)) {
+      sid = sid_string;
+      LocalFree(sid_string);
+    }
+  }
+
+  CloseHandle(handle);
+  return sid;
+}
+
+std::string GetPipName(const std::string& base, bool user_specific) {
+  std::string pipename = "\\\\.\\pipe\\" + base;
+  if (user_specific) {
+    pipename += ".";
+    std::string sid = GetUserSID();
+    if (sid.empty())
+      return std::string();
+
+    pipename += +"." + sid;
+  }
+
+  return pipename;
+}
+
+}  // internal
+}  // namespace sdk
+}  // namespace content_analysis

--- a/common/utils_win.cc
+++ b/common/utils_win.cc
@@ -44,7 +44,7 @@ std::string GetUserSID() {
   return sid;
 }
 
-std::string GetPipName(const std::string& base, bool user_specific) {
+std::string GetPipeName(const std::string& base, bool user_specific) {
   std::string pipename = "\\\\.\\pipe\\" + base;
   if (user_specific) {
     pipename += ".";

--- a/common/utils_win.h
+++ b/common/utils_win.h
@@ -1,0 +1,30 @@
+// Copyright 2022 The Chromium Authors.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Utility and helper functions common to both the agent and browser code.
+// This code is not publicly exposed from the SDK.
+
+#ifndef CONTENT_ANALYSIS_COMMON_UTILS_WIN_H_
+#define CONTENT_ANALYSIS_COMMON_UTILS_WIN_H_
+
+#include <string>
+
+namespace content_analysis {
+namespace sdk {
+namespace internal {
+
+// Returns the user SID of the thread or process that calls thie function.
+// Returns an empty string on error.
+std::string GetUserSID();
+
+// Returns the name of the pipe that should be used to communicate between
+// the agent and Google Chrome.  If `sid` is non-empty, make the pip name
+// specific to that user.
+std::string GetPipName(const std::string& base, bool user_specific);
+
+}  // internal
+}  // namespace sdk
+}  // namespace content_analysis
+
+#endif  // CONTENT_ANALYSIS_COMMON_UTILS_WIN_H_

--- a/common/utils_win.h
+++ b/common/utils_win.h
@@ -21,7 +21,7 @@ std::string GetUserSID();
 // Returns the name of the pipe that should be used to communicate between
 // the agent and Google Chrome.  If `sid` is non-empty, make the pip name
 // specific to that user.
-std::string GetPipName(const std::string& base, bool user_specific);
+std::string GetPipeName(const std::string& base, bool user_specific);
 
 }  // internal
 }  // namespace sdk

--- a/demo/agent.cc
+++ b/demo/agent.cc
@@ -147,7 +147,7 @@ void AnalyzeContent(std::unique_ptr<Session> session) {
 
 int main(int argc, char* argv[]) {
   // Each agent uses a unique URI to identify itself with Google Chrome.
-  auto agent = Agent::Create("content_analysis_sdk");
+  auto agent = Agent::Create({"content_analysis_sdk"});
   if (!agent) {
     std::cout << "[Demo] Error starting agent" << std::endl;
     return 1;

--- a/demo/client.cc
+++ b/demo/client.cc
@@ -89,7 +89,7 @@ void PrintHelp() {
 
 int main(int argc, char* argv[]) {
   // Each client uses a unique URI to identify itself with Google Chrome.
-  auto client = Client::Create("content_analysis_sdk");
+  auto client = Client::Create({"content_analysis_sdk"});
   if (!client) {
     std::cout << "[Demo] Error starting client" << std::endl;
     return 1;

--- a/demo/queued_agent_posix.cc
+++ b/demo/queued_agent_posix.cc
@@ -252,7 +252,7 @@ int main(int argc, char* argv[]) {
   pthread_attr_destroy(&attr);
 
   // Each agent uses a unique URI to identify itself with Google Chrome.
-  auto agent = Agent::Create("content_analysis_sdk");
+  auto agent = Agent::Create({"content_analysis_sdk"});
   if (!agent) {
     std::cout << "[Demo] Error starting agent" << std::endl;
     return 1;

--- a/demo/queued_agent_win.cc
+++ b/demo/queued_agent_win.cc
@@ -244,7 +244,7 @@ int main(int argc, char* argv[]) {
       nullptr, 0, ProcessRequests, &request_queue, 0, &tid));
 
   // Each agent uses a unique URI to identify itself with Google Chrome.
-  auto agent = Agent::Create("content_analysis_sdk");
+  auto agent = Agent::Create({"content_analysis_sdk", true});
   if (!agent) {
     std::cout << "[Demo] Error starting agent" << std::endl;
     return 1;


### PR DESCRIPTION
In some cases, each OS user may have its own instance of a content analysis agent.
Make sure that Google Chrome can connect to the right agent when needed.