### PR TITLE
Add more tests for Agent::Stop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ include(GoogleTest)
 add_executable(unit_tests
   ${PLATFORM_TEST_CODE}
 )
+set_property(TARGET unit_tests PROPERTY CXX_STANDARD 20)
 target_include_directories(unit_tests
   PRIVATE
   ${AGENT_INCLUDES}

--- a/agent/src/agent_win.cc
+++ b/agent/src/agent_win.cc
@@ -71,7 +71,8 @@ DWORD AgentWin::Connection::Reset(const std::string& pipename) {
 DWORD AgentWin::Connection::HandleEvent(HANDLE handle) {
   DWORD err = ERROR_SUCCESS;
   DWORD count;
-  BOOL success = GetOverlappedResult(handle, &overlapped_, &count, FALSE);
+  BOOL success = GetOverlappedResult(handle, &overlapped_, &count,
+                                     /*wait=*/FALSE);
   if (!is_connected_) {
     // This connection is currently listing for a new connection from a Google
     // Chrome browser.  If the result is a success, this means the browser has
@@ -409,6 +410,15 @@ DWORD AgentWin::HandleOneEventForTesting() {
   std::vector<HANDLE> wait_handles;
   bool stopped;
   return HandleOneEvent(wait_handles, &stopped);
+}
+
+bool AgentWin::IsAClientConnectedForTesting() {
+  for (const auto& state : connections_) {
+    if (state->IsConnected()) {
+      return true;
+    }
+  }
+  return false;
 }
 
 DWORD AgentWin::HandleOneEvent(std::vector<HANDLE>& wait_handles, bool* stopped) {

--- a/agent/src/agent_win.h
+++ b/agent/src/agent_win.h
@@ -29,6 +29,9 @@ class AgentWin : public AgentBase {
   // Handles one pipe event and returns.  Used only in tests.
   DWORD HandleOneEventForTesting();
 
+  // Returns true if there is at least one client connected to this agent.
+  bool IsAClientConnectedForTesting();
+
 private:
   // Represents one connection to a Google Chrome browser, or one pipe
   // listening for a Google Chrome browser to connect.


### PR DESCRIPTION
This PR adds some more tests for Agent::Stop() scenarios.  May need to add follow up tests as we try other scenarios.