### PR TITLE
Fix filepath condition in demo client

### DIFF
--- a/demo/client.cc
+++ b/demo/client.cc
@@ -105,10 +105,10 @@ ContentAnalysisRequest BuildRequest(const std::string& data) {
     request_data->set_filename(filename);
   }
 
-  if (!data.empty()) {
-    request.set_text_content(data);
-  } else if (!filepath.empty()) {
+  if (!filepath.empty()) {
     request.set_file_path(filepath);
+  } else if (!data.empty()) {
+    request.set_text_content(data);
   } else {
     std::cout << "[Demo] Specify text content or a file path." << std::endl;
     PrintHelp();


### PR DESCRIPTION
The order of the condition with the function params makes it so the `!filepath.empty()` condition is never reached since `data` is always non-empty for `filepath` to be populated.