### PR TITLE
Fix windows pipe permissions.

### DIFF
--- a/agent/src/agent_win.h
+++ b/agent/src/agent_win.h
@@ -48,10 +48,14 @@ private:
     // occurs while creating the connction object it is returned in `rc`.
     // If no errors occur then rc is set to ResultCode::OK.
     //
+    // When `user_specific` is true there is a different agent instance per OS
+    // user.
+    //
     // `Connection` objects cannot be copied or moved because the OVERLAPPED
     // structure cannot be changed or moved in memory while an I/O operation
     // is in progress.
     Connection(const std::string& pipename,
+               bool user_specific,
                AgentEventHandler* handler,
                bool is_first_pipe,
                ResultCode* rc);
@@ -66,7 +70,9 @@ private:
     HANDLE GetWaitHandle() const { return overlapped_.hEvent; }
 
     // Resets this connection object to listen for a new Google Chrome browser.
-    ResultCode Reset(const std::string& pipename);
+    // When `user_specific` is true there is a different agent instance per OS
+    // user.
+    ResultCode Reset(const std::string& pipename, bool user_specific);
 
     // Hnadles an event for this connection.  `wait_handle` corresponds to
     // this connections wait handle.
@@ -80,7 +86,11 @@ private:
     ResultCode ConnectPipe();
 
     // Resets this connection object to listen for a new Google Chrome browser.
-    ResultCode ResetInternal(const std::string& pipename, bool is_first_pipe);
+    // When `user_specific` is true there is a different agent instance per OS
+    // user.
+    ResultCode ResetInternal(const std::string& pipename,
+                             bool user_specific,
+                             bool is_first_pipe);
 
     // Cleans up this connection object so that it can be reused with a new
     // Google Chroem browser instance.  The handles assocated with this object

--- a/agent/src/event_win_unittest.cc
+++ b/agent/src/event_win_unittest.cc
@@ -85,7 +85,7 @@ TEST(EventTest, Create_Init_RequestNoRequestToken) {
 TEST(EventTest, Write_BadPipe) {
   HANDLE pipe;
   DWORD err = internal::CreatePipe(
-      internal::GetPipeName("testpipe", false), true, &pipe);
+      internal::GetPipeName("testpipe", false), false, true, &pipe);
   ASSERT_EQ(ERROR_SUCCESS, err);
   ASSERT_NE(INVALID_HANDLE_VALUE, pipe);
 

--- a/browser/src/client_win.cc
+++ b/browser/src/client_win.cc
@@ -18,18 +18,25 @@ const DWORD kBufferSize = 4096;
 
 // static
 std::unique_ptr<Client> Client::Create(Config config) {
-  return std::make_unique<ClientWin>(std::move(config));
+  int rc;
+  auto client = std::make_unique<ClientWin>(std::move(config), &rc);
+  return rc == 0 ? std::move(client) : nullptr;
 }
 
-ClientWin::ClientWin(Config config) : ClientBase(std::move(config)) {
+ClientWin::ClientWin(Config config, int* rc) : ClientBase(std::move(config)) {
+  *rc = -1;
+
   std::string pipename =
     internal::GetPipeName(configuration().name, configuration().user_specific);
-  if (pipename.empty())
+  if (pipename.empty()) {
     return;
+  }
 
   pipename_ = pipename;
   if (ConnectToPipe(pipename_, &hPipe_) != ERROR_SUCCESS) {
     Shutdown();
+  } else {
+    *rc = 0;
   }
 }
 

--- a/browser/src/client_win.h
+++ b/browser/src/client_win.h
@@ -15,7 +15,7 @@ namespace sdk {
 // Client implementaton for Windows.
 class ClientWin : public ClientBase {
  public:
-   ClientWin(Config config);
+   ClientWin(Config config, int* rc);
    ~ClientWin() override;
 
   // Client:

--- a/common/utils_win.cc
+++ b/common/utils_win.cc
@@ -77,11 +77,11 @@ DWORD CreatePipe(
   //
   // See https://docs.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-definition-language
   // for a description of this string format.
-  const char* kDaclEveryone = "D:"
+  constexpr char* kDaclEveryone = "D:"
       "(A;OICI;GA;;;CO)"     // Allow full control to creator owner.
       "(A;OICI;GA;;;BA)"     // Allow full control to admins.
       "(A;OICI;GRGW;;;WD)";  // Allow read and write to everyone.
-  const char* kDaclUserSpecific = "D:"
+  constexpr char* kDaclUserSpecific = "D:"
       "(A;OICI;GA;;;CO)"     // Allow full control to creator owner.
       "(A;OICI;GA;;;BA)"     // Allow full control to admins.
       "(A;OICI;GRGW;;;IU)";  // Allow read and write to interactive user.
@@ -111,6 +111,8 @@ DWORD CreatePipe(
     err = GetLastError();
   }
 
+  // Free the security descriptor as it is no longer needed once
+  // CreateNamedPipeA() returns.
   LocalFree(sa.lpSecurityDescriptor);
 
   return err;

--- a/common/utils_win.cc
+++ b/common/utils_win.cc
@@ -59,10 +59,42 @@ std::string GetPipeName(const std::string& base, bool user_specific) {
 
 DWORD CreatePipe(
     const std::string& name,
+    bool user_specific,
     bool is_first_pipe,
     HANDLE* handle) {
   DWORD err = ERROR_SUCCESS;
   DWORD mode = PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED;
+
+  // Create DACL for pipe to allow users on the local system to read and write
+  // to the pipe.  The creator and owner as well as administrator always get
+  // full control of the pipe.
+  //
+  // If `user_specific` is true, a different agent instance is used for each
+  // OS user, so only allow the interactive logged on user to reads and write
+  // messages to the pipe.  Otherwise only one agent instance used used for all
+  // OS users and all authenticated logged on users can reads and write
+  // messages.
+  //
+  // See https://docs.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-definition-language
+  // for a description of this string format.
+  const char* kDaclEveryone = "D:"
+      "(A;OICI;GA;;;CO)"     // Allow full control to creator owner.
+      "(A;OICI;GA;;;BA)"     // Allow full control to admins.
+      "(A;OICI;GRGW;;;WD)";  // Allow read and write to everyone.
+  const char* kDaclUserSpecific = "D:"
+      "(A;OICI;GA;;;CO)"     // Allow full control to creator owner.
+      "(A;OICI;GA;;;BA)"     // Allow full control to admins.
+      "(A;OICI;GRGW;;;IU)";  // Allow read and write to interactive user.
+  SECURITY_ATTRIBUTES sa;
+  memset(&sa, 0, sizeof(sa));
+  sa.nLength = sizeof(sa);
+  sa.bInheritHandle = FALSE;
+  if (!ConvertStringSecurityDescriptorToSecurityDescriptorA(
+      user_specific ? kDaclUserSpecific : kDaclEveryone, SDDL_REVISION_1,
+      &sa.lpSecurityDescriptor, /*outSdSize=*/nullptr)) {
+    err = GetLastError();
+    return err;
+  }
 
   // When `is_first_pipe` is true, the agent expects there is no process that
   // is currently listening on this pipe.  If there is, CreateNamedPipeA()
@@ -74,10 +106,12 @@ DWORD CreatePipe(
   *handle = CreateNamedPipeA(name.c_str(), mode,
     PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT |
     PIPE_REJECT_REMOTE_CLIENTS, PIPE_UNLIMITED_INSTANCES, kBufferSize,
-    kBufferSize, 0, /*securityAttr=*/nullptr);
+    kBufferSize, 0, &sa);
   if (*handle == INVALID_HANDLE_VALUE) {
     err = GetLastError();
   }
+
+  LocalFree(sa.lpSecurityDescriptor);
 
   return err;
 }

--- a/common/utils_win.h
+++ b/common/utils_win.h
@@ -28,9 +28,18 @@ std::string GetUserSID();
 std::string GetPipeName(const std::string& base, bool user_specific);
 
 // Creates a named pipe with the give name.  If `is_first_pipe` is true,
-// fail if this is not the first pipe using this name.  A handle to the
-// pipe is retuned in `handle`.
-DWORD CreatePipe(const std::string& name,bool is_first_pipe,HANDLE* handle);
+// fail if this is not the first pipe using this name.
+//
+// This function create a pipe whose DACL allow full control to the creator
+// owner and administrators.  If `user_specific` the DACL only allows the
+// logged on user to read from and write to the pipe.  Otherwise anyone logged
+// in can read from and write to the pipe.
+//
+// A handle to the pipe is retuned in `handle`.
+DWORD CreatePipe(const std::string& name,
+                 bool user_specific,
+                 bool is_first_pipe,
+                 HANDLE* handle);
 
 }  // internal
 }  // namespace sdk

--- a/demo/agent.cc
+++ b/demo/agent.cc
@@ -9,10 +9,47 @@
 #include "content_analysis/sdk/analysis_agent.h"
 #include "demo/handler.h"
 
+// Global app config.
+bool user_specific = false;
+
+// Command line parameters.
+constexpr const char* kArgUserSpecific = "--user";
+constexpr const char* kArgHelp = "--help";
+
+bool ParseCommandLine(int argc, char* argv[]) {
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg.find(kArgUserSpecific) == 0) {
+      user_specific = true;
+    } else if (arg.find(kArgHelp) == 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void PrintHelp() {
+  std::cout
+    << std::endl << std::endl
+    << "Usage: agent [OPTIONS]" << std::endl
+    << "A simple agent to process content analysis requests." << std::endl
+    << "Data containing the string 'block' blocks the request data from being used." << std::endl
+    << std::endl << "Options:"  << std::endl
+    << kArgUserSpecific << " : Make agent OS user specific" << std::endl
+    << kArgHelp << " : prints this help message" << std::endl;
+}
+
 int main(int argc, char* argv[]) {
+  if (!ParseCommandLine(argc, argv)) {
+    PrintHelp();
+    return 1;
+  }
+
   // Each agent uses a unique name to identify itself with Google Chrome.
   content_analysis::sdk::ResultCode rc;
-  auto agent = content_analysis::sdk::Agent::Create({"content_analysis_sdk"},
+  auto agent = content_analysis::sdk::Agent::Create(
+      {"content_analysis_sdk", user_specific},
       std::make_unique<Handler>(), &rc);
   if (!agent || rc != content_analysis::sdk::ResultCode::OK) {
     std::cout << "[Demo] Error starting agent: "

--- a/demo/client.cc
+++ b/demo/client.cc
@@ -13,6 +13,9 @@ using content_analysis::sdk::ContentAnalysisRequest;
 using content_analysis::sdk::ContentAnalysisResponse;
 using content_analysis::sdk::ContentAnalysisAcknowledgement;
 
+// Global app config.
+bool user_specific = false;
+
 // Paramters used to build the request.
 content_analysis::sdk::AnalysisConnector connector =
     content_analysis::sdk::FILE_ATTACHED;
@@ -28,6 +31,7 @@ constexpr const char* kArgRequestToken = "--request-token=";
 constexpr const char* kArgTag = "--tag=";
 constexpr const char* kArgDigest = "--digest=";
 constexpr const char* kArgUrl = "--url=";
+constexpr const char* kArgUserSpecific = "--user";
 constexpr const char* kArgHelp = "--help";
 
 bool ParseCommandLine(int argc, char* argv[]) {
@@ -57,6 +61,8 @@ bool ParseCommandLine(int argc, char* argv[]) {
       digest = arg.substr(strlen(kArgDigest));
     } else if (arg.find(kArgUrl) == 0) {
       url = arg.substr(strlen(kArgUrl));
+    } else if (arg.find(kArgUserSpecific) == 0) {
+      user_specific = true;
     } else if (arg.find(kArgHelp) == 0) {
       return false;
     } else {
@@ -80,6 +86,7 @@ void PrintHelp() {
     << kArgRequestToken << "<unique-token> : defaults to 'req-12345'" << std::endl
     << kArgTag << "<tag> : defaults to 'dlp'" << std::endl
     << kArgUrl << "<url> : defaults to 'https://upload.example.com'" << std::endl
+    << kArgUserSpecific << " : Connects to an OS user specific agent" << std::endl
     << kArgDigest << "<digest> : defaults to 'sha256-123456'" << std::endl
     << kArgHelp << " : prints this help message" << std::endl;
 }
@@ -211,7 +218,7 @@ int main(int argc, char* argv[]) {
   }
 
   // Each client uses a unique name to identify itself with Google Chrome.
-  auto client = Client::Create({"content_analysis_sdk"});
+  auto client = Client::Create({"content_analysis_sdk", user_specific});
   if (!client) {
     std::cout << "[Demo] Error starting client" << std::endl;
     return 1;


### PR DESCRIPTION
When the agent is not running in user specific mode, it should
allow any process running in the interactive user's logon session
to send content analysis requests.  Otherwise the agent should
allow any process that is running as a logged on user to send
requests.