### PR TITLE
Fix demo agent request dump message

### DIFF
--- a/demo/client.cc
+++ b/demo/client.cc
@@ -105,10 +105,10 @@ ContentAnalysisRequest BuildRequest(const std::string& data) {
     request_data->set_filename(filename);
   }
 
-  if (!data.empty()) {
-    request.set_text_content(data);
-  } else if (!filepath.empty()) {
+  if (!filepath.empty()) {
     request.set_file_path(filepath);
+  } else if (!data.empty()) {
+    request.set_text_content(data);
   } else {
     std::cout << "[Demo] Specify text content or a file path." << std::endl;
     PrintHelp();


### PR DESCRIPTION
As of crrev.com/c/3878325, the `file_path` field being empty won't necessarily indicate that a bulk text entry is happening as it could also be a print. This change updates the corresponding log message to reflect that.