### PR TITLE
Fix demo agent request dump message

### DIFF
--- a/demo/handler.h
+++ b/demo/handler.h
@@ -182,7 +182,7 @@ class Handler : public content_analysis::sdk::AgentEventHandler {
 
     std::string file_path =
         request.has_file_path()
-        ? request.file_path() : "None, bulk text entry";
+        ? request.file_path() : "None, bulk text entry or print";
 
     std::string machine_user =
         request.has_client_metadata() &&


### PR DESCRIPTION
As of crrev.com/c/3878325, the `file_path` field being empty won't necessarily indicate that a bulk text entry is happening as it could also be a print. This change updates the corresponding log message to reflect that.