### PR TITLE
Let a request handling delay be specified on the agent command line

### DIFF
--- a/demo/agent.cc
+++ b/demo/agent.cc
@@ -52,7 +52,7 @@ void PrintHelp() {
     << "Data containing the string 'block' blocks the request data from being used." << std::endl
     << std::endl << "Options:"  << std::endl
     << kArgUserSpecific << " : Make agent OS user specific" << std::endl
-    << kArgDelaySpecific << "<delay> : Add the delay to request processing in seconds" << std::endl
+    << kArgDelaySpecific << "<delay> : Add a delay to request processing in seconds (max 30)." << std::endl
     << kArgHelp << " : prints this help message" << std::endl;
 }
 

--- a/demo/agent.cc
+++ b/demo/agent.cc
@@ -18,9 +18,11 @@ constexpr char kPathSystem[] = "path_system";
 // Global app config.
 const char* path = kPathSystem;
 bool user_specific = false;
+unsigned long delay = 0;  // In seconds.
 
 // Command line parameters.
 constexpr const char* kArgUserSpecific = "--user";
+constexpr const char* kArgDelaySpecific = "--delay=";
 constexpr const char* kArgHelp = "--help";
 
 bool ParseCommandLine(int argc, char* argv[]) {
@@ -29,6 +31,11 @@ bool ParseCommandLine(int argc, char* argv[]) {
     if (arg.find(kArgUserSpecific) == 0) {
       path = kPathUser;
       user_specific = true;
+    } else if (arg.find(kArgDelaySpecific) == 0) {
+      delay = std::stoul(arg.substr(strlen(kArgDelaySpecific)));
+      if (delay > 30) {
+          delay = 30;
+      }
     } else if (arg.find(kArgHelp) == 0) {
       return false;
     }
@@ -45,6 +52,7 @@ void PrintHelp() {
     << "Data containing the string 'block' blocks the request data from being used." << std::endl
     << std::endl << "Options:"  << std::endl
     << kArgUserSpecific << " : Make agent OS user specific" << std::endl
+    << kArgDelaySpecific << "<delay> : Add the delay to request processing in seconds" << std::endl
     << kArgHelp << " : prints this help message" << std::endl;
 }
 
@@ -57,7 +65,7 @@ int main(int argc, char* argv[]) {
   // Each agent uses a unique name to identify itself with Google Chrome.
   content_analysis::sdk::ResultCode rc;
   auto agent = content_analysis::sdk::Agent::Create(
-      {path, user_specific}, std::make_unique<Handler>(), &rc);
+      {path, user_specific}, std::make_unique<Handler>(delay), &rc);
   if (!agent || rc != content_analysis::sdk::ResultCode::OK) {
     std::cout << "[Demo] Error starting agent: "
               << content_analysis::sdk::ResultCodeToString(rc)

--- a/demo/handler.h
+++ b/demo/handler.h
@@ -76,7 +76,7 @@ class Handler : public content_analysis::sdk::AgentEventHandler {
 
     // If a delay is specified, wait that much.
     if (delay_ > 0) {
-      std::cout << "[Demo] delaying request for " << delay_ << "s" << std::endl;
+      std::cout << "[Demo] delaying request processing for " << delay_ << "s" << std::endl;
       std::this_thread::sleep_for(std::chrono::seconds(delay_));
     }
 

--- a/demo/handler.h
+++ b/demo/handler.h
@@ -7,6 +7,7 @@
 
 #include <time.h>
 
+#include <chrono>
 #include <fstream>
 #include <iostream>
 #include <utility>
@@ -19,7 +20,7 @@ class Handler : public content_analysis::sdk::AgentEventHandler {
  public:
   using Event = content_analysis::sdk::ContentAnalysisEvent;
 
-  Handler() = default;
+  Handler(unsigned long delay) : delay_(delay) {}
 
  protected:
   // Analyzes one request from Google Chrome and responds back to the browser
@@ -72,6 +73,12 @@ class Handler : public content_analysis::sdk::AgentEventHandler {
     }
 
     std::cout << std::endl;
+
+    // If a delay is specified, wait that much.
+    if (delay_ > 0) {
+      std::cout << "[Demo] delaying request for " << delay_ << "s" << std::endl;
+      std::this_thread::sleep_for(std::chrono::seconds(delay_));
+    }
 
     // Send the response back to Google Chrome.
     auto rc = event->Send();
@@ -245,6 +252,8 @@ class Handler : public content_analysis::sdk::AgentEventHandler {
     // content is allowed.
     return content.find("block") != std::string::npos;
   }
+
+  unsigned long delay_;
 };
 
 #endif  // CONTENT_ANALYSIS_DEMO_HANDLER_H_

--- a/demo/queued_agent.cc
+++ b/demo/queued_agent.cc
@@ -55,7 +55,7 @@ void PrintHelp() {
     << "Data containing the string 'block' blocks the request data from being used." << std::endl
     << std::endl << "Options:"  << std::endl
     << kArgUserSpecific << " : Make agent OS user specific" << std::endl
-    << kArgDelaySpecific << "<delay> : Add the delay to request processing in seconds" << std::endl
+    << kArgDelaySpecific << "<delay> : Add a delay to request processing in seconds (max 30)." << std::endl
     << kArgHelp << " : prints this help message" << std::endl;
 }
 

--- a/demo/queued_agent.cc
+++ b/demo/queued_agent.cc
@@ -21,9 +21,11 @@ constexpr char kPathSystem[] = "path_system";
 // Global app config.
 const char* path = kPathSystem;
 bool user_specific = false;
+unsigned long delay = 0;  // In seconds.
 
 // Command line parameters.
 constexpr const char* kArgUserSpecific = "--user";
+constexpr const char* kArgDelaySpecific = "--delay=";
 constexpr const char* kArgHelp = "--help";
 
 bool ParseCommandLine(int argc, char* argv[]) {
@@ -32,6 +34,11 @@ bool ParseCommandLine(int argc, char* argv[]) {
     if (arg.find(kArgUserSpecific) == 0) {
       path = kPathUser;
       user_specific = true;
+    } else if (arg.find(kArgDelaySpecific) == 0) {
+      delay = std::stoul(arg.substr(strlen(kArgDelaySpecific)));
+      if (delay > 30) {
+          delay = 30;
+      }
     } else if (arg.find(kArgHelp) == 0) {
       return false;
     }
@@ -48,6 +55,7 @@ void PrintHelp() {
     << "Data containing the string 'block' blocks the request data from being used." << std::endl
     << std::endl << "Options:"  << std::endl
     << kArgUserSpecific << " : Make agent OS user specific" << std::endl
+    << kArgDelaySpecific << "<delay> : Add the delay to request processing in seconds" << std::endl
     << kArgHelp << " : prints this help message" << std::endl;
 }
 
@@ -55,7 +63,7 @@ void PrintHelp() {
 // any requests that have the keyword "block" in their data
 class QueuingHandler : public Handler {
  public:
-  QueuingHandler() {
+  QueuingHandler(unsigned long delay) : Handler(delay)  {
     StartBackgroundThread();
   }
 
@@ -108,7 +116,7 @@ int main(int argc, char* argv[]) {
   // Each agent uses a unique name to identify itself with Google Chrome.
   content_analysis::sdk::ResultCode rc;
   auto agent = content_analysis::sdk::Agent::Create({path, user_specific},
-      std::make_unique<QueuingHandler>(), &rc);
+      std::make_unique<QueuingHandler>(delay), &rc);
   if (!agent || rc != content_analysis::sdk::ResultCode::OK) {
     std::cout << "[Demo] Error starting agent: "
               << content_analysis::sdk::ResultCodeToString(rc)


### PR DESCRIPTION
This helps to simulate content analyses that can take longer time.