### PR TITLE
Add AgentInfo structure to Client

### DIFF
--- a/agent/include/content_analysis/sdk/analysis_agent.h
+++ b/agent/include/content_analysis/sdk/analysis_agent.h
@@ -43,7 +43,7 @@ namespace sdk {
 // Represents information about one instance of a Google Chrome browser
 // process that is connected to the agent.
 struct BrowserInfo {
-  unsigned long pid = 0;  // Process of Google Chrome browser process.
+  unsigned long pid = 0;  // Process ID of Google Chrome browser process.
   std::string binary_path;  // The full path to the process's main binary.
 };
 

--- a/agent/include/content_analysis/sdk/result_codes.inc
+++ b/agent/include/content_analysis/sdk/result_codes.inc
@@ -12,7 +12,6 @@ RC_RECOVERABLE(ERR_INVALID_REQUEST_FROM_BROWSER, "The browser sent an incorrectl
 RC_RECOVERABLE(ERR_IO_PENDING, "IO incomplete, the operation is still pending.")
 RC_RECOVERABLE(ERR_MORE_DATA, "There is more data to read before the entire message has been received.")
 RC_RECOVERABLE(ERR_CANNOT_GET_BROWSER_PID, "Cannot get process Id of browser.")
-RC_RECOVERABLE(ERR_CANNOT_OPEN_BROWSER_PROCESS, "Cannot open browser process to extract info.")
 RC_RECOVERABLE(ERR_CANNOT_GET_BROWSER_BINARY_PATH, "Cannot get the full path to the brower's main binary file.")
 RC_RECOVERABLE(ERR_BROKEN_PIPE, "Browser process has disconnected.")
 RC_RECOVERABLE(ERR_UNEXPECTED, "An internal error has occured.")

--- a/agent/src/agent_win.cc
+++ b/agent/src/agent_win.cc
@@ -336,26 +336,12 @@ ResultCode AgentWin::Connection::BuildBrowserInfo() {
                          ResultCode::ERR_CANNOT_GET_BROWSER_PID);
   }
 
-  HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE,
-      browser_info_.pid);
-  if (hProc == nullptr) {
-    return NotifyIfError("BuildBrowserInfo",
-                         ResultCode::ERR_CANNOT_OPEN_BROWSER_PROCESS);
-  }
-  
-  auto rc = ResultCode::OK;
-  char path[MAX_PATH];
-  DWORD size = sizeof(path);
-  DWORD length = QueryFullProcessImageNameA(hProc, /*flags=*/0, path, &size);
-  if (length == 0) {
-    rc = NotifyIfError("BuildBrowserInfo",
-                       ResultCode::ERR_CANNOT_GET_BROWSER_BINARY_PATH);
+  if (!internal::GetProcessPath(browser_info_.pid,
+                                &browser_info_.binary_path)) {
+    return ResultCode::ERR_CANNOT_GET_BROWSER_BINARY_PATH;
   }
 
-  CloseHandle(hProc);
-
-  browser_info_.binary_path = path;
-  return rc;
+  return ResultCode::OK;
 }
 
 ResultCode AgentWin::Connection::NotifyIfError(

--- a/agent/src/agent_win.cc
+++ b/agent/src/agent_win.cc
@@ -338,7 +338,8 @@ ResultCode AgentWin::Connection::BuildBrowserInfo() {
 
   if (!internal::GetProcessPath(browser_info_.pid,
                                 &browser_info_.binary_path)) {
-    return ResultCode::ERR_CANNOT_GET_BROWSER_BINARY_PATH;
+    return NotifyIfError("BuildBrowserInfo",
+                         ResultCode::ERR_CANNOT_GET_BROWSER_BINARY_PATH);
   }
 
   return ResultCode::OK;

--- a/browser/include/content_analysis/sdk/analysis_client.h
+++ b/browser/include/content_analysis/sdk/analysis_client.h
@@ -20,6 +20,13 @@
 namespace content_analysis {
 namespace sdk {
 
+// Represents information about one instance of a content analysis agent
+// process that is connected to the browser.
+struct AgentInfo {
+  unsigned long pid = 0;  // Process ID of content analysis agent process.
+  std::string binary_path;  // The full path to the process's main binary.
+};
+
 // Represents a client that can request content analysis for locally running
 // agent.  This class holds the client endpoint that the browser connects
 // with when content analysis is required.
@@ -47,6 +54,9 @@ class Client {
 
   // Returns the configuration parameters used to create the client.
   virtual const Config& GetConfig() const = 0;
+
+  // Retrives information about the agent that is connected to the browser.
+  virtual const AgentInfo& GetAgentInfo() const = 0;
 
   // Sends an analysis request to the agent and waits for a response.
   virtual int Send(const ContentAnalysisRequest& request,

--- a/browser/src/client_base.cc
+++ b/browser/src/client_base.cc
@@ -13,5 +13,9 @@ const Client::Config& ClientBase::GetConfig() const {
   return config_;
 }
 
+const AgentInfo& ClientBase::GetAgentInfo() const {
+  return agent_info_;
+}
+
 }  // namespace sdk
 }  // namespace content_analysis

--- a/browser/src/client_base.h
+++ b/browser/src/client_base.h
@@ -15,14 +15,17 @@ class ClientBase : public Client {
  public:
   // Client:
   const Config& GetConfig() const override;
+  const AgentInfo& GetAgentInfo() const override;
 
  protected:
   ClientBase(Config config);
 
   const Config& configuration() const { return config_; }
+  AgentInfo& agent_info() { return agent_info_; }
 
 private:
   Config config_;
+  AgentInfo agent_info_;
 };
 
 }  // namespace sdk

--- a/browser/src/client_win.cc
+++ b/browser/src/client_win.cc
@@ -28,15 +28,21 @@ ClientWin::ClientWin(Config config, int* rc) : ClientBase(std::move(config)) {
 
   std::string pipename =
     internal::GetPipeName(configuration().name, configuration().user_specific);
-  if (pipename.empty()) {
-    return;
+  if (!pipename.empty()) {
+    unsigned long pid;
+    std::string binary_path;
+    if (ConnectToPipe(pipename, &hPipe_) == ERROR_SUCCESS &&
+        GetNamedPipeServerProcessId(hPipe_, &pid) &&
+        internal::GetProcessPath(pid, &binary_path)) {
+      pipename_ = pipename;
+      agent_info().pid = pid;
+      agent_info().binary_path = std::move(binary_path);
+      *rc = 0;
+    }
   }
 
-  pipename_ = pipename;
-  if (ConnectToPipe(pipename_, &hPipe_) != ERROR_SUCCESS) {
+  if (*rc != 0) {
     Shutdown();
-  } else {
-    *rc = 0;
   }
 }
 

--- a/browser/src/client_win.cc
+++ b/browser/src/client_win.cc
@@ -29,7 +29,7 @@ ClientWin::ClientWin(Config config, int* rc) : ClientBase(std::move(config)) {
   std::string pipename =
     internal::GetPipeName(configuration().name, configuration().user_specific);
   if (!pipename.empty()) {
-    unsigned long pid;
+    unsigned long pid = 0;
     std::string binary_path;
     if (ConnectToPipe(pipename, &hPipe_) == ERROR_SUCCESS &&
         GetNamedPipeServerProcessId(hPipe_, &pid) &&

--- a/browser/src/client_win.cc
+++ b/browser/src/client_win.cc
@@ -34,7 +34,6 @@ ClientWin::ClientWin(Config config, int* rc) : ClientBase(std::move(config)) {
     if (ConnectToPipe(pipename, &hPipe_) == ERROR_SUCCESS &&
         GetNamedPipeServerProcessId(hPipe_, &pid) &&
         internal::GetProcessPath(pid, &binary_path)) {
-      pipename_ = pipename;
       agent_info().pid = pid;
       agent_info().binary_path = std::move(binary_path);
       *rc = 0;

--- a/browser/src/client_win.h
+++ b/browser/src/client_win.h
@@ -37,7 +37,6 @@ class ClientWin : public ClientBase {
   // Performs a clean shutdown of the client.
   void Shutdown();
 
-  std::string pipename_;
   HANDLE hPipe_ = INVALID_HANDLE_VALUE;
 };
 

--- a/common/utils_win.cc
+++ b/common/utils_win.cc
@@ -118,6 +118,24 @@ DWORD CreatePipe(
   return err;
 }
 
+bool GetProcessPath(unsigned long pid, std::string* binary_path) {
+  HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+  if (hProc == nullptr) {
+    return false;
+  }
+  
+  char path[MAX_PATH];
+  DWORD size = sizeof(path);
+  DWORD length = QueryFullProcessImageNameA(hProc, /*flags=*/0, path, &size);
+  CloseHandle(hProc);
+  if (length == 0) {
+    return false;
+  }
+
+  *binary_path = path;
+  return true;
+}
+
 }  // internal
 }  // namespace sdk
 }  // namespace content_analysis

--- a/common/utils_win.h
+++ b/common/utils_win.h
@@ -41,6 +41,10 @@ DWORD CreatePipe(const std::string& name,
                  bool is_first_pipe,
                  HANDLE* handle);
 
+// Returns the full path to the main binary file of the process with the given
+// process ID.
+bool GetProcessPath(unsigned long pid, std::string* binary_path);
+
 }  // internal
 }  // namespace sdk
 }  // namespace content_analysis

--- a/demo/client.cc
+++ b/demo/client.cc
@@ -322,6 +322,10 @@ int main(int argc, char* argv[]) {
     return 1;
   };
 
+  auto info = client->GetAgentInfo();
+  std::cout << "Agent pid=" << info.pid
+            << " path=" << info.binary_path << std::endl;
+
   ContentAnalysisAcknowledgement::FinalAction final_action =
       ContentAnalysisAcknowledgement::ALLOW;
   for (int i = 0; i < datas.size(); ++i) {

--- a/demo/handler.h
+++ b/demo/handler.h
@@ -96,7 +96,8 @@ class Handler : public content_analysis::sdk::AgentEventHandler {
   void OnBrowserConnected(
       const content_analysis::sdk::BrowserInfo& info) override {
     std::cout << std::endl << "==========" << std::endl;
-    std::cout << "Browser connected pid=" << info.pid << std::endl;
+    std::cout << "Browser connected pid=" << info.pid
+              << " path=" << info.binary_path << std::endl;
   }
 
   void OnBrowserDisconnected(


### PR DESCRIPTION
This allows the browser to get information about the server so that it can verify that it is the expected server.