### PR TITLE
Make agent path best effort

### DIFF
--- a/browser/src/client_win.cc
+++ b/browser/src/client_win.cc
@@ -30,13 +30,16 @@ ClientWin::ClientWin(Config config, int* rc) : ClientBase(std::move(config)) {
     internal::GetPipeName(configuration().name, configuration().user_specific);
   if (!pipename.empty()) {
     unsigned long pid = 0;
-    std::string binary_path;
     if (ConnectToPipe(pipename, &hPipe_) == ERROR_SUCCESS &&
-        GetNamedPipeServerProcessId(hPipe_, &pid) &&
-        internal::GetProcessPath(pid, &binary_path)) {
+        GetNamedPipeServerProcessId(hPipe_, &pid)) {
       agent_info().pid = pid;
-      agent_info().binary_path = std::move(binary_path);
-      *rc = 0;
+
+      // Getting the process path is best effort.
+       *rc = 0;
+      std::string binary_path;
+      if (internal::GetProcessPath(pid, &binary_path)) {
+        agent_info().binary_path = std::move(binary_path);
+      }
     }
   }
 

--- a/browser/src/client_win.cc
+++ b/browser/src/client_win.cc
@@ -35,7 +35,7 @@ ClientWin::ClientWin(Config config, int* rc) : ClientBase(std::move(config)) {
       agent_info().pid = pid;
 
       // Getting the process path is best effort.
-       *rc = 0;
+      *rc = 0;
       std::string binary_path;
       if (internal::GetProcessPath(pid, &binary_path)) {
         agent_info().binary_path = std::move(binary_path);


### PR DESCRIPTION
It's possible the google chrome browser can't get the full path to the agent due to permission issues.  Make getting the path best effort only and don't block the connection.