### PR TITLE
Switch print handle duping from browser to agent

### DIFF
--- a/agent/include/content_analysis/sdk/analysis_agent.h
+++ b/agent/include/content_analysis/sdk/analysis_agent.h
@@ -96,28 +96,6 @@ class ContentAnalysisEvent {
   // for debugging.
   virtual std::string DebugString() const = 0;
 
-  // Helper class to handle the lifetime and access of print data.
-  class ScopedPrintHandle {
-   public:
-    virtual ~ScopedPrintHandle() = default;
-    virtual const char* data() = 0;
-    virtual size_t size() = 0;
-
-   protected:
-    ScopedPrintHandle() = default;
-
-    ScopedPrintHandle(const ScopedPrintHandle&) = delete;
-    ScopedPrintHandle& operator=(const ScopedPrintHandle&) = delete;
-
-    ScopedPrintHandle(ScopedPrintHandle&&) = default;
-    ScopedPrintHandle& operator=(ScopedPrintHandle&&) = default;
-  };
-
-  // Returns a `ScopedPrintHandle` initialized from the event's print data
-  // if it exists. This only returns a non-null value at most once to avoid
-  // having duplicate handles initialized.
-  virtual std::unique_ptr<ScopedPrintHandle> TakeScopedPrintHandle() = 0;
-
  protected:
   ContentAnalysisEvent() = default;
   ContentAnalysisEvent(const ContentAnalysisEvent& rhs) = delete;
@@ -280,6 +258,29 @@ ResultCode SetEventVerdictTo(
 //   SetEventVerdictTo(event,
 //                     ContentAnalysisResponse::Result::TriggeredRule::BLOCK);
 ResultCode SetEventVerdictToBlock(ContentAnalysisEvent* event);
+
+// Helper class to handle the lifetime and access of print data.
+class ScopedPrintHandle {
+ public:
+  virtual ~ScopedPrintHandle() = default;
+  virtual const char* data() = 0;
+  virtual size_t size() = 0;
+
+ protected:
+  ScopedPrintHandle() = default;
+
+  ScopedPrintHandle(const ScopedPrintHandle&) = delete;
+  ScopedPrintHandle& operator=(const ScopedPrintHandle&) = delete;
+
+  ScopedPrintHandle(ScopedPrintHandle&&) = default;
+  ScopedPrintHandle& operator=(ScopedPrintHandle&&) = default;
+};
+
+// Returns a `ScopedPrintHandle` initialized from the request's print data
+// if it exists.
+std::unique_ptr<ScopedPrintHandle>
+CreateScopedPrintHandle(const ContentAnalysisRequest& request,
+                        int64_t browser_pid);
 
 }  // namespace sdk
 }  // namespace content_analysis

--- a/agent/src/event_base.h
+++ b/agent/src/event_base.h
@@ -26,8 +26,6 @@ class ContentAnalysisEventBase : public ContentAnalysisEvent {
   AgentToChrome* agent_to_chrome() { return &agent_to_chrome_; }
   ContentAnalysisResponse* response() { return agent_to_chrome()->mutable_response(); }
 
-  bool scoped_print_handle_taken_ = false;
-
 private:
   BrowserInfo browser_info_;
   ContentAnalysisRequest request_;

--- a/agent/src/event_mac.cc
+++ b/agent/src/event_mac.cc
@@ -24,15 +24,6 @@ std::string ContentAnalysisEventMac::DebugString() const {
   return std::string();
 }
 
-std::unique_ptr<ContentAnalysisEvent::ScopedPrintHandle>
-ContentAnalysisEventMac::TakeScopedPrintHandle() {
-  if (!GetRequest().has_print_data() || scoped_print_handle_taken_) {
-    return nullptr;
-  }
-
-  scoped_print_handle_taken_ = true;
-  return std::make_unique<ScopedPrintHandleMac>(GetRequest().print_data());
-}
 
 }  // namespace sdk
 }  // namespace content_analysis

--- a/agent/src/event_mac.h
+++ b/agent/src/event_mac.h
@@ -19,7 +19,6 @@ class ContentAnalysisEventMac : public ContentAnalysisEventBase {
   // ContentAnalysisEvent:
   ResultCode Send() override;
   std::string DebugString() const override;
-  std::unique_ptr<ScopedPrintHandle> TakeScopedPrintHandle() override;
 
   // TODO(rogerta): Fill in implementation.
 };

--- a/agent/src/event_posix.cc
+++ b/agent/src/event_posix.cc
@@ -24,15 +24,5 @@ std::string ContentAnalysisEventPosix::DebugString() const {
   return std::string();
 }
 
-std::unique_ptr<ContentAnalysisEvent::ScopedPrintHandle>
-ContentAnalysisEventPosix::TakeScopedPrintHandle() {
-  if (!GetRequest().has_print_data() || scoped_print_handle_taken_) {
-    return nullptr;
-  }
-
-  scoped_print_handle_taken_ = true;
-  return std::make_unique<ScopedPrintHandlePosix>(GetRequest().print_data());
-}
-
 }  // namespace sdk
 }  // namespace content_analysis

--- a/agent/src/event_posix.h
+++ b/agent/src/event_posix.h
@@ -19,7 +19,6 @@ class ContentAnalysisEventPosix : public ContentAnalysisEventBase {
   // ContentAnalysisEvent:
   ResultCode Send() override;
   std::string DebugString() const override;
-  std::unique_ptr<ScopedPrintHandle> TakeScopedPrintHandle() override;
 
   // TODO(rogerta): Fill in implementation.
 };

--- a/agent/src/event_win.cc
+++ b/agent/src/event_win.cc
@@ -130,20 +130,6 @@ void ContentAnalysisEventWin::Shutdown() {
     FlushFileBuffers(hPipe_);
     hPipe_ = INVALID_HANDLE_VALUE;
   }
-
-  // Taking the print handle here ensures the dupe handle is closed
-  // correctly if needed.
-  auto scoped_handle = TakeScopedPrintHandle();
-}
-
-std::unique_ptr<ContentAnalysisEvent::ScopedPrintHandle>
-ContentAnalysisEventWin::TakeScopedPrintHandle() {
-  if (!GetRequest().has_print_data() || scoped_print_handle_taken_) {
-    return nullptr;
-  }
-
-  scoped_print_handle_taken_ = true;
-  return std::make_unique<ScopedPrintHandleWin>(GetRequest().print_data());
 }
 
 }  // namespace sdk

--- a/agent/src/event_win.h
+++ b/agent/src/event_win.h
@@ -28,7 +28,6 @@ class ContentAnalysisEventWin : public ContentAnalysisEventBase {
   ResultCode Close() override;
   ResultCode Send() override;
   std::string DebugString() const override;
-  std::unique_ptr<ScopedPrintHandle> TakeScopedPrintHandle() override;
 
  private:
   void Shutdown();

--- a/agent/src/scoped_print_handle_base.h
+++ b/agent/src/scoped_print_handle_base.h
@@ -10,7 +10,7 @@
 namespace content_analysis {
 namespace sdk {
 
-class ScopedPrintHandleBase : public ContentAnalysisEvent::ScopedPrintHandle {
+class ScopedPrintHandleBase : public ScopedPrintHandle {
  public:
   ScopedPrintHandleBase(const ContentAnalysisRequest::PrintData& print_data);
 

--- a/agent/src/scoped_print_handle_mac.cc
+++ b/agent/src/scoped_print_handle_mac.cc
@@ -7,6 +7,16 @@
 namespace content_analysis {
 namespace sdk {
 
+std::unique_ptr<ScopedPrintHandle>
+CreateScopedPrintHandle(const ContentAnalysisRequest& request,
+                        int64_t browser_pid) {
+  if (!request.has_print_data() || !request.print_data().has_handle()) {
+    return nullptr;
+  }
+
+  return std::make_unique<ScopedPrintHandleMac>(request.print_data());
+}
+
 ScopedPrintHandleMac::ScopedPrintHandleMac(
     const ContentAnalysisRequest::PrintData& print_data)
     : ScopedPrintHandleBase(print_data) {

--- a/agent/src/scoped_print_handle_posix.cc
+++ b/agent/src/scoped_print_handle_posix.cc
@@ -7,7 +7,15 @@
 namespace content_analysis {
 namespace sdk {
 
+std::unique_ptr<ScopedPrintHandle>
+CreateScopedPrintHandle(const ContentAnalysisRequest& request,
+                        int64_t browser_pid) {
+  if (!request.has_print_data() || !request.print_data().has_handle()) {
+    return nullptr;
+  }
 
+  return std::make_unique<ScopedPrintHandlePosix>(request.print_data());
+}
 
 ScopedPrintHandlePosix::ScopedPrintHandlePosix(
     const ContentAnalysisRequest::PrintData& print_data)

--- a/agent/src/scoped_print_handle_win.cc
+++ b/agent/src/scoped_print_handle_win.cc
@@ -7,6 +7,43 @@
 namespace content_analysis {
 namespace sdk {
 
+std::unique_ptr<ScopedPrintHandle>
+CreateScopedPrintHandle(const ContentAnalysisRequest& request,
+                        int64_t browser_pid) {
+  if (!request.has_print_data() || !request.print_data().has_handle()) {
+    return nullptr;
+  }
+
+  // The handle in the request must be duped to be read by the agent
+  // process. If that doesn't work for any reason, return null.
+  // See https://learn.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-duplicatehandle
+  // for details.
+  HANDLE browser_process = OpenProcess(
+      /*dwDesiredAccess=*/PROCESS_DUP_HANDLE,
+      /*bInheritHandle=*/false,
+      /*dwProcessId=*/browser_pid);
+  if (!browser_process)
+    return nullptr;
+
+  HANDLE dupe = nullptr;
+  DuplicateHandle(
+      /*hSourceProcessHandle=*/browser_process,
+      /*hSourceHandle=*/reinterpret_cast<HANDLE>(request.print_data().handle()),
+      /*hTargetProcessHandle=*/GetCurrentProcess(),
+      /*lpTargetHandle=*/&dupe,
+      /*dwDesiredAccess=*/PROCESS_DUP_HANDLE | FILE_MAP_READ,
+      /*bInheritHandle=*/false,
+      /*dwOptions=*/0);
+  if (!dupe)
+    return nullptr;
+
+  ContentAnalysisRequest::PrintData dupe_print_data;
+  dupe_print_data.set_handle(reinterpret_cast<int64_t>(dupe));
+  dupe_print_data.set_size(request.print_data().size());
+
+  return std::make_unique<ScopedPrintHandleWin>(dupe_print_data);
+}
+
 ScopedPrintHandleWin::ScopedPrintHandleWin(
     const ContentAnalysisRequest::PrintData& print_data)
     : ScopedPrintHandleBase(print_data),

--- a/browser/src/client_win.h
+++ b/browser/src/client_win.h
@@ -34,12 +34,6 @@ class ClientWin : public ClientBase {
   // Writes a string to the pipe. Returns True if successful, else returns False.
   static bool WriteMessageToPipe(HANDLE pipe, const std::string& message);
 
-  // Get a duplicate handle for printed data using DuplicateHandle.
-  // See https://learn.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-duplicatehandle
-  // for details. The target process is the one corresponding to `hPipe_`, and
-  // errors or an invalid `hPipe_` will result in this function returning null.
-  HANDLE CreateDuplicatePrintDataHandle(HANDLE print_data);
-
   // Performs a clean shutdown of the client.
   void Shutdown();
 

--- a/demo/handler.h
+++ b/demo/handler.h
@@ -242,7 +242,9 @@ class Handler : public content_analysis::sdk::AgentEventHandler {
       std::cout << "  Print data saved to: " << print_data_file_path_
                 << std::endl;
       using content_analysis::sdk::ContentAnalysisEvent;
-      auto print_data = event->TakeScopedPrintHandle();
+      auto print_data =
+          content_analysis::sdk::CreateScopedPrintHandle(event->GetRequest(),
+                   event->GetBrowserInfo().pid);
       std::ofstream file(print_data_file_path_,
                          std::ios::out | std::ios::trunc | std::ios::binary);
       file.write(print_data->data(), print_data->size());


### PR DESCRIPTION
This PR makes the print data handle duping logic happen in the content analysis agent instead of the browser. This allows to fix permission issues when the agent runs at a higher privilege than the browser. To support this and make the interface simpler to use, the `ScopedPrintHandle` class and factory function are also refactored out of `ContentAnalysisEvent`.