### PR TITLE
Use a pipe protected namespace name

### DIFF
--- a/common/utils_win.cc
+++ b/common/utils_win.cc
@@ -45,7 +45,7 @@ std::string GetUserSID() {
 }
 
 std::string GetPipeName(const std::string& base, bool user_specific) {
-  std::string pipename = "\\\\.\\pipe\\" + base;
+  std::string pipename = "\\\\.\\pipe\\ProtectedPrefix\\Administrators\\" + base;
   if (user_specific) {
     std::string sid = GetUserSID();
     if (sid.empty())

--- a/demo/README.md
+++ b/demo/README.md
@@ -4,3 +4,6 @@ This directory holds the Google Chrome Content Analysis Connector Agent SDK Demo
 It contains an example of how to use the SDK.
 
 Build instructions are available in the main project `README.md`.
+
+On Micosoft Windows, the dummy agent needs to run as Administrator in order to
+properly create the pipe used to communicate with the browser.

--- a/demo/README.md
+++ b/demo/README.md
@@ -5,5 +5,5 @@ It contains an example of how to use the SDK.
 
 Build instructions are available in the main project `README.md`.
 
-On Micosoft Windows, the dummy agent needs to run as Administrator in order to
+On Micosoft Windows, the demo agent needs to run as Administrator in order to
 properly create the pipe used to communicate with the browser.


### PR DESCRIPTION
On Windows, the pipe used to communicate between the agent and browser is now created under a standard pipe protected namespace to guard against:

- a non-admin malicious app trying to use the named pipe of a different DLP agent
- a non-admin malicious app creating a symlink to cause a denial of service for a DLP agent