### PR TITLE
Don't use pipe symlink on client

### DIFF
--- a/agent/src/agent_win.cc
+++ b/agent/src/agent_win.cc
@@ -518,7 +518,6 @@ ResultCode AgentWin::HandleOneEvent(
   // If `connection` was listening and is now connected, create a new
   // one so that there are always kMinNumListeningPipeInstances listening.
   if (rc == ResultCode::OK && was_listening && connection->IsConnected()) {
-    Sleep(120000);
     connections_.emplace_back(
         std::make_unique<Connection>(pipename_, configuration().user_specific,
                                      handler(), false, &rc));

--- a/agent/src/agent_win.cc
+++ b/agent/src/agent_win.cc
@@ -505,7 +505,7 @@ ResultCode AgentWin::HandleOneEvent(
   auto rc = connection->HandleEvent(wait_handles[index]);
   if (rc != ResultCode::OK) {
     // If `connection` was not listening and there are more than
-    // kNumPipeInstances pipes, delete this connection.  Otherwise
+    // kMinNumListeningPipeInstances pipes, delete this connection.  Otherwise
     // reset it so that it becomes a listener.
     if (!was_listening &&
       connections_.size() > kMinNumListeningPipeInstances) {
@@ -516,8 +516,9 @@ ResultCode AgentWin::HandleOneEvent(
   }
 
   // If `connection` was listening and is now connected, create a new
-  // one so that there are always kNumPipeInstances listening.
+  // one so that there are always kMinNumListeningPipeInstances listening.
   if (rc == ResultCode::OK && was_listening && connection->IsConnected()) {
+    Sleep(120000);
     connections_.emplace_back(
         std::make_unique<Connection>(pipename_, configuration().user_specific,
                                      handler(), false, &rc));

--- a/agent/src/agent_win.cc
+++ b/agent/src/agent_win.cc
@@ -382,8 +382,8 @@ AgentWin::AgentWin(
   }
 
   std::string pipename =
-      internal::GetPipeName(configuration().name,
-                            configuration().user_specific);
+      internal::GetPipeNameForAgent(configuration().name,
+                                    configuration().user_specific);
   if (pipename.empty()) {
     *rc = ResultCode::ERR_INVALID_CHANNEL_NAME;
     return;

--- a/agent/src/agent_win.h
+++ b/agent/src/agent_win.h
@@ -182,8 +182,8 @@ private:
   std::string pipename_;
 
   // A list of pipes to already connected Google Chrome browsers.
-  // The first kNumPipeInstances pipes in the list correspond to listening
-  // pipes.
+  // The first kMinNumListeningPipeInstances pipes in the list correspond to
+  // listening pipes.
   std::vector<std::unique_ptr<Connection>> connections_;
 
   // An event that is set when the agent should stop.  Set in Stop().

--- a/agent/src/event_win_unittest.cc
+++ b/agent/src/event_win_unittest.cc
@@ -85,7 +85,7 @@ TEST(EventTest, Create_Init_RequestNoRequestToken) {
 TEST(EventTest, Write_BadPipe) {
   HANDLE pipe;
   DWORD err = internal::CreatePipe(
-      internal::GetPipeName("testpipe", false), false, true, &pipe);
+      internal::GetPipeNameForAgent("testpipe", false), false, true, &pipe);
   ASSERT_EQ(ERROR_SUCCESS, err);
   ASSERT_NE(INVALID_HANDLE_VALUE, pipe);
 

--- a/browser/src/client_win.cc
+++ b/browser/src/client_win.cc
@@ -93,6 +93,7 @@ bool WaitForPipeAvailability(const UNICODE_STRING& path) {
       reinterpret_cast<FILE_PIPE_WAIT_FOR_BUFFER*>(buffer.data());
   wait_buffer->Timeout.QuadPart = kDefaultTimeout;
   wait_buffer->NameLength = pipe_name.Length;
+  wait_buffer->TimeoutSpecified = TRUE;
   std::wcsncpy(wait_buffer->Name, pipe_name.Buffer, wait_buffer->NameLength /
       sizeof(wchar_t));
 

--- a/common/utils_win.cc
+++ b/common/utils_win.cc
@@ -44,8 +44,13 @@ std::string GetUserSID() {
   return sid;
 }
 
-std::string GetPipeName(const std::string& base, bool user_specific) {
-  std::string pipename = "\\\\.\\pipe\\ProtectedPrefix\\Administrators\\" + base;
+std::string BuildPipeName(const char* prefix,
+                          const std::string& base,
+                          bool user_specific) {
+  std::string pipename = prefix;
+  pipename += "\\ProtectedPrefix\\Administrators\\";
+  pipename += base;
+
   if (user_specific) {
     std::string sid = GetUserSID();
     if (sid.empty())
@@ -55,6 +60,14 @@ std::string GetPipeName(const std::string& base, bool user_specific) {
   }
 
   return pipename;
+}
+
+std::string GetPipeNameForAgent(const std::string& base, bool user_specific) {
+  return BuildPipeName("\\\\.\\pipe", base, user_specific);
+}
+
+std::string GetPipeNameForClient(const std::string& base, bool user_specific) {
+  return BuildPipeName("\\Device\\NamedPipe", base, user_specific);
 }
 
 DWORD CreatePipe(

--- a/common/utils_win.cc
+++ b/common/utils_win.cc
@@ -48,13 +48,12 @@ std::string BuildPipeName(const char* prefix,
                           const std::string& base,
                           bool user_specific) {
   std::string pipename = prefix;
-  pipename += "\\ProtectedPrefix\\Administrators\\";
+  pipename += "ProtectedPrefix\\Administrators\\";
   pipename += base;
 
   if (user_specific) {
     std::string sid = GetUserSID();
     if (sid.empty())
-      return std::string();
 
     pipename += "." + sid;
   }
@@ -63,11 +62,11 @@ std::string BuildPipeName(const char* prefix,
 }
 
 std::string GetPipeNameForAgent(const std::string& base, bool user_specific) {
-  return BuildPipeName("\\\\.\\pipe", base, user_specific);
+  return BuildPipeName(kPipePrefixForAgent, base, user_specific);
 }
 
 std::string GetPipeNameForClient(const std::string& base, bool user_specific) {
-  return BuildPipeName("\\Device\\NamedPipe", base, user_specific);
+  return BuildPipeName(kPipePrefixForClient, base, user_specific);
 }
 
 DWORD CreatePipe(

--- a/common/utils_win.cc
+++ b/common/utils_win.cc
@@ -54,6 +54,7 @@ std::string BuildPipeName(const char* prefix,
   if (user_specific) {
     std::string sid = GetUserSID();
     if (sid.empty())
+      return std::string();
 
     pipename += "." + sid;
   }

--- a/common/utils_win.h
+++ b/common/utils_win.h
@@ -25,7 +25,13 @@ std::string GetUserSID();
 // Returns the name of the pipe that should be used to communicate between
 // the agent and Google Chrome.  If `sid` is non-empty, make the pip name
 // specific to that user.
-std::string GetPipeName(const std::string& base, bool user_specific);
+//
+// GetPipeNameForAgent() is meant to be used in the agent.  The returned
+// path can be used with CreatePipe() below.  GetPipeNameForClient() is meant
+// to be used in the client.  The returned path can only be used with
+// NtCreateFile() and not CreateFile().
+std::string GetPipeNameForAgent(const std::string& base, bool user_specific);
+std::string GetPipeNameForClient(const std::string& base, bool user_specific);
 
 // Creates a named pipe with the give name.  If `is_first_pipe` is true,
 // fail if this is not the first pipe using this name.

--- a/common/utils_win.h
+++ b/common/utils_win.h
@@ -19,8 +19,8 @@ namespace internal {
 const DWORD kBufferSize = 4096;
 
 // Named pipe prefixes used for agent and client side of pipe.
-constexpr char kPipePrefixForAgent[] = "\\\\.\\pipe\\";
-constexpr char kPipePrefixForClient[] = "\\Device\\NamedPipe\\";
+constexpr char kPipePrefixForAgent[] = R"(\\.\\pipe\)";
+constexpr char kPipePrefixForClient[] = R"(\Device\NamedPipe\)";
 
 // Returns the user SID of the thread or process that calls thie function.
 // Returns an empty string on error.

--- a/common/utils_win.h
+++ b/common/utils_win.h
@@ -18,6 +18,10 @@ namespace internal {
 // Google Chrome.
 const DWORD kBufferSize = 4096;
 
+// Named pipe prefixes used for agent and client side of pipe.
+constexpr char kPipePrefixForAgent[] = "\\\\.\\pipe\\";
+constexpr char kPipePrefixForClient[] = "\\Device\\NamedPipe\\";
+
 // Returns the user SID of the thread or process that calls thie function.
 // Returns an empty string on error.
 std::string GetUserSID();


### PR DESCRIPTION
The named pipe prefix `\\.\pipe` is a OS user specific symlink in the kernel object namespace which points to `\Device\NamedPipe`.  In order to prevent an non-admin app, running in the same OS user context as the client browser, from redirecting this symlink elsewhere, the client will always use the pipe prefix `\Device\NamedPipe` to build the full path to the named pipe.  Using the latter path means the client must call `NtCreateFile` instead of the win32 `CreateFile`.