### PR TITLE
Use overlapped IO in the SDK client

### DIFF
--- a/browser/src/client_win.cc
+++ b/browser/src/client_win.cc
@@ -161,9 +161,9 @@ std::vector<char> ReadNextMessageFromPipe(
     DWORD read;
 
     // Even though the pipe is opened for overlapped IO, the read operation
-    // could still completely synchrnously.  For example, a server's response
+    // could still completely synchronously.  For example, a server's response
     // message could already be available in the pipe's internal buffer.
-    // If ReadFile() does complete synchrnously, TRUE is returned.  In this
+    // If ReadFile() does complete synchronously, TRUE is returned.  In this
     // case update the final size and exit the loop.
     if (ReadFile(pipe, p, kBufferSize, &read, overlapped)) {
       final_size += read;
@@ -220,7 +220,7 @@ bool WriteMessageToPipe(
     return false;
 
   // Even though the pipe is opened for overlapped IO, the write operation
-  // could still completely synchrnously.  If it does, TRUE is returned.
+  // could still completely synchronously.  If it does, TRUE is returned.
   // In this case the function is done.
   bool ok = WriteFile(pipe, message.data(), message.size(), nullptr, overlapped);
   if (!ok) {

--- a/browser/src/client_win.h
+++ b/browser/src/client_win.h
@@ -27,13 +27,6 @@ class ClientWin : public ClientBase {
  private:
   static DWORD ConnectToPipe(const std::string& pipename, HANDLE* handle);
 
-  // Reads the next message from the pipe and returns a buffer of chars.
-  // Can read any length of message.
-  static std::vector<char> ReadNextMessageFromPipe(HANDLE pipe);
-
-  // Writes a string to the pipe. Returns True if successful, else returns False.
-  static bool WriteMessageToPipe(HANDLE pipe, const std::string& message);
-
   // Performs a clean shutdown of the client.
   void Shutdown();
 

--- a/common/utils_win.cc
+++ b/common/utils_win.cc
@@ -155,6 +155,20 @@ bool GetProcessPath(unsigned long pid, std::string* binary_path) {
   return true;
 }
 
+ScopedOverlapped::ScopedOverlapped() {
+  memset(&overlapped_, 0, sizeof(overlapped_));
+  overlapped_.hEvent = CreateEvent(/*securityAttr=*/nullptr,
+                                   /*manualReset=*/TRUE,
+                                   /*initialState=*/FALSE,
+                                   /*name=*/nullptr);
+}
+
+ScopedOverlapped::~ScopedOverlapped() {
+  if (overlapped_.hEvent != nullptr) {
+    CloseHandle(overlapped_.hEvent);
+  }
+}
+
 }  // internal
 }  // namespace sdk
 }  // namespace content_analysis

--- a/common/utils_win.h
+++ b/common/utils_win.h
@@ -55,6 +55,20 @@ DWORD CreatePipe(const std::string& name,
 // process ID.
 bool GetProcessPath(unsigned long pid, std::string* binary_path);
 
+// A class that scopes the creation and destruction of an OVERLAPPED structure
+// used for async IO.
+class ScopedOverlapped {
+ public:
+  ScopedOverlapped();
+  ~ScopedOverlapped();
+
+  bool is_valid() { return overlapped_.hEvent != nullptr; }
+  operator OVERLAPPED*() { return &overlapped_; }
+
+ private:
+  OVERLAPPED overlapped_;
+};
+
 }  // internal
 }  // namespace sdk
 }  // namespace content_analysis

--- a/demo/handler.h
+++ b/demo/handler.h
@@ -340,17 +340,11 @@ class QueuingHandler : public Handler {
       if (!event)
         break;
 
-      time_t now = time(nullptr);
-      const content_analysis::sdk::ContentAnalysisRequest& request =
-          event->GetRequest();
-
       AtomicCout aout;
       aout.stream()  << std::endl << "----------" << std::endl;
       aout.stream() << "Thread: " << std::this_thread::get_id() << std::endl;
-      aout.stream() << "Starting request: " << request.request_token()
-                    << " at " << ctime(&now);
       aout.stream() << "Delaying request processing for "
-                    << handler->delay() << "s" << std::endl;
+                    << handler->delay() << "s" << std::endl << std::endl;
       aout.flush();
 
       handler->AnalyzeContent(aout.stream(), std::move(event));


### PR DESCRIPTION
The client should be opened for overlapped IO in order to all multitple threads to call Client::Send() concurrently.  If the pipe is opened in sync mode, then only one Send() call can run to completion at a time.