### PR TITLE
Add Reason enum to ContentAnalysisRequest

### DIFF
--- a/demo/handler.h
+++ b/demo/handler.h
@@ -182,25 +182,45 @@ class Handler : public content_analysis::sdk::AgentEventHandler {
         event->GetRequest();
     std::string connector = "<Unknown>";
     if (request.has_analysis_connector()) {
-      switch (request.analysis_connector())
-      {
-      case content_analysis::sdk::FILE_DOWNLOADED:
-        connector = "download";
-        break;
-      case content_analysis::sdk::FILE_ATTACHED:
-        connector = "attach";
-        break;
-      case content_analysis::sdk::BULK_DATA_ENTRY:
-        connector = "bulk-data-entry";
-        break;
-      case content_analysis::sdk::PRINT:
-        connector = "print";
-        break;
-      case content_analysis::sdk::FILE_TRANSFER:
-        connector = "file-transfer";
-        break;
-      default:
-        break;
+      switch (request.analysis_connector()) {
+        case content_analysis::sdk::FILE_DOWNLOADED:
+          connector = "download";
+          break;
+        case content_analysis::sdk::FILE_ATTACHED:
+          connector = "attach";
+          break;
+        case content_analysis::sdk::BULK_DATA_ENTRY:
+          connector = "bulk-data-entry";
+          break;
+        case content_analysis::sdk::PRINT:
+          connector = "print";
+          break;
+        case content_analysis::sdk::FILE_TRANSFER:
+          connector = "file-transfer";
+          break;
+        default:
+          break;
+      }
+    }
+    std::string reason;
+    if (request.has_reason()) {
+      switch (request.reason()) {
+        case UNKNOWN:
+          reason = "<Unknown>";
+        case CLIPBOARD_PASTE:
+          reason = "CLIPBOARD_PASTE";
+        case DRAG_AND_DROP:
+          reason = "DRAG_AND_DROP";
+        case FILE_PICKER_DIALOG:
+          reason = "DRAG_AND_DROP";
+        case PRINT_PREVIEW_PRINT:
+          reason = "DRAG_AND_DROP";
+        case SYSTEM_DIALOG_PRINT:
+          reason = "DRAG_AND_DROP";
+        case NORMAL_DOWNLOAD:
+          reason = "DRAG_AND_DROP";
+        case SAVE_AS_DOWNLOAD:
+          reason = "DRAG_AND_DROP";
       }
     }
 
@@ -248,6 +268,9 @@ class Handler : public content_analysis::sdk::AgentEventHandler {
     stream << "  Expires at: " << expires_at_str << " ("
            << secs_remaining << " seconds from now)" << std::endl;
     stream << "  Connector: " << connector << std::endl;
+    if (!reason.empty()) {
+      stream << "  Reason: " << reason << std::endl;
+    }
     stream << "  URL: " << url << std::endl;
     stream << "  Tab title: " << tab_title << std::endl;
     stream << "  Filename: " << filename << std::endl;

--- a/demo/handler.h
+++ b/demo/handler.h
@@ -204,23 +204,24 @@ class Handler : public content_analysis::sdk::AgentEventHandler {
     }
     std::string reason;
     if (request.has_reason()) {
+      using content_analysis::sdk::ContentAnalysisRequest;
       switch (request.reason()) {
-        case UNKNOWN:
+        case content_analysis::sdk::ContentAnalysisRequest::UNKNOWN:
           reason = "<Unknown>";
-        case CLIPBOARD_PASTE:
+        case content_analysis::sdk::ContentAnalysisRequest::CLIPBOARD_PASTE:
           reason = "CLIPBOARD_PASTE";
-        case DRAG_AND_DROP:
+        case content_analysis::sdk::ContentAnalysisRequest::DRAG_AND_DROP:
           reason = "DRAG_AND_DROP";
-        case FILE_PICKER_DIALOG:
-          reason = "DRAG_AND_DROP";
-        case PRINT_PREVIEW_PRINT:
-          reason = "DRAG_AND_DROP";
-        case SYSTEM_DIALOG_PRINT:
-          reason = "DRAG_AND_DROP";
-        case NORMAL_DOWNLOAD:
-          reason = "DRAG_AND_DROP";
-        case SAVE_AS_DOWNLOAD:
-          reason = "DRAG_AND_DROP";
+        case content_analysis::sdk::ContentAnalysisRequest::FILE_PICKER_DIALOG:
+          reason = "FILE_PICKER_DIALOG";
+        case content_analysis::sdk::ContentAnalysisRequest::PRINT_PREVIEW_PRINT:
+          reason = "PRINT_PREVIEW_PRINT";
+        case content_analysis::sdk::ContentAnalysisRequest::SYSTEM_DIALOG_PRINT:
+          reason = "SYSTEM_DIALOG_PRINT";
+        case content_analysis::sdk::ContentAnalysisRequest::NORMAL_DOWNLOAD:
+          reason = "NORMAL_DOWNLOAD";
+        case content_analysis::sdk::ContentAnalysisRequest::SAVE_AS_DOWNLOAD:
+          reason = "SAVE_AS_DOWNLOAD";
       }
     }
 

--- a/proto/content_analysis/sdk/analysis.proto
+++ b/proto/content_analysis/sdk/analysis.proto
@@ -159,24 +159,24 @@ message ContentAnalysisRequest {
   // Indicates the exact reason the request was created, ie which user action
   // led to a data transfer.
   enum Reason {
-    UNKNOWN = 0,
+    UNKNOWN = 0;
 
     // Only possible for the `FILE_ATTACHED` and `BULK_DATA_ENTRY` actions.
-    CLIPBOARD_PASTE = 1,
-    DRAG_AND_DROP = 2,
+    CLIPBOARD_PASTE = 1;
+    DRAG_AND_DROP = 2;
 
     // Only possible for the `FILE_ATTACHED` action.
-    FILE_PICKER_DIALOG = 3,
+    FILE_PICKER_DIALOG = 3;
 
     // Only possible for the `PRINT` analysis connector.
-    PRINT_PREVIEW_PRINT = 4,
-    SYSTEM_DIALOG_PRINT = 5,
+    PRINT_PREVIEW_PRINT = 4;
+    SYSTEM_DIALOG_PRINT = 5;
 
     // Only possible for the `FILE_DOWNLOADED` analysis connector.
-    NORMAL_DOWNLOAD = 6,
-    SAVE_AS_DOWNLOAD = 7,
+    NORMAL_DOWNLOAD = 6;
+    SAVE_AS_DOWNLOAD = 7;
   }
-  optional Reason reason = 18;
+  optional Reason reason = 19;
 
   // Reserved to make sure there is no overlap with DeepScanningClientRequest.
   reserved 1 to 4, 6 to 8;

--- a/proto/content_analysis/sdk/analysis.proto
+++ b/proto/content_analysis/sdk/analysis.proto
@@ -156,6 +156,28 @@ message ContentAnalysisRequest {
   // Count of analysis requests that belong to the same user action.
   optional int64 user_action_requests_count = 17;
 
+  // Indicates the exact reason the request was created, ie which user action
+  // led to a data transfer.
+  enum Reason {
+    UNKNOWN = 0,
+
+    // Only possible for the `FILE_ATTACHED` and `BULK_DATA_ENTRY` actions.
+    CLIPBOARD_PASTE = 1,
+    DRAG_AND_DROP = 2,
+
+    // Only possible for the `FILE_ATTACHED` action.
+    FILE_PICKER_DIALOG = 3,
+
+    // Only possible for the `PRINT` analysis connector.
+    PRINT_PREVIEW_PRINT = 4,
+    SYSTEM_DIALOG_PRINT = 5,
+
+    // Only possible for the `FILE_DOWNLOADED` analysis connector.
+    NORMAL_DOWNLOAD = 6,
+    SAVE_AS_DOWNLOAD = 7,
+  }
+  optional Reason reason = 18;
+
   // Reserved to make sure there is no overlap with DeepScanningClientRequest.
   reserved 1 to 4, 6 to 8;
 }


### PR DESCRIPTION
This adds a new Reason enum and field to ContentAnalysisRequest to capture the user action leading to a scan more precisely.  This also updates the demo agent to log that new field.