### PR TITLE
Delay per request.

### DIFF
--- a/demo/client.cc
+++ b/demo/client.cc
@@ -317,7 +317,7 @@ void HandleRequest(const ContentAnalysisRequest& request) {
         global_final_action = final_action;
     } else {
       int err = client->Acknowledge(
-        BuildAcknowledgement(request.request_token(), final_action));
+        BuildAcknowledgement(response.request_token(), final_action));
       if (err != 0) {
         aout.stream() << "[Demo] Error sending ack " << request.request_token()
                       << std::endl;


### PR DESCRIPTION
Add ability to specify a response delay per request.  For text and file requests, the body to be scanned needs to have the string `delay=x` where x is the delay in seconds.  For print requests, the URL should have a parameter of the form `delay=x`.

To test, run the demo agent as follows:
```
   agent --user --queued
```
Run the demo client as follows (sends two requests, one whose response is delayed 7 seconds, the other not delyaed):
```
   browser --user --threaded "allow delay=7" "block"
```
Test print use cases with chrome.  Make sure to add `&delay=x` to the URL before printing.

This commit includes some tiddying up of the output in the demo agent.  It also includes a fix in the demo client that assumed responses were sent in the same order as the requests.