### PR TITLE
Return null configs for Mac and Posix

### DIFF
--- a/browser/src/client_mac.cc
+++ b/browser/src/client_mac.cc
@@ -11,7 +11,7 @@ namespace sdk {
 
 // static
 std::unique_ptr<Client> Client::Create(Config config) {
-  return std::make_unique<ClientMac>(std::move(config));
+  return nullptr;
 }
 
 ClientMac::ClientMac(Config config) : ClientBase(std::move(config)) {}

--- a/browser/src/client_posix.cc
+++ b/browser/src/client_posix.cc
@@ -11,7 +11,7 @@ namespace sdk {
 
 // static
 std::unique_ptr<Client> Client::Create(Config config) {
-  return std::make_unique<ClientPosix>(std::move(config));
+  return nullptr;
 }
 
 ClientPosix::ClientPosix(Config config) : ClientBase(std::move(config)) {}


### PR DESCRIPTION
This tweaks the existing `ClientMac::Create` and `ClientPosix::Create` implementations to return `nullptr` until they are implemented. Doing this will allow browser code to reliably detect if a local agent can be used or not, just like `ClientWin::Create`.