### PR TITLE
Fix response truncation for messages >4KB on Windows named-pipes

### DIFF
--- a/browser/src/client_win.cc
+++ b/browser/src/client_win.cc
@@ -192,6 +192,8 @@ std::vector<char> ReadNextMessageFromPipe(
         break;
       }
 
+      final_size += read;
+
       // Reaching here means the error is "more data", that is, the buffer
       // specified in ReadFile() was too small to contain the entire response
       // message from the server. ReadFile() has placed the start of the

--- a/demo/client.cc
+++ b/demo/client.cc
@@ -84,6 +84,8 @@ bool ParseCommandLine(int argc, char* argv[]) {
         connector = content_analysis::sdk::PRINT;
       } else if (connector_str == "file-transfer") {
         connector = content_analysis::sdk::FILE_TRANSFER;
+      } else if (connector_str == "data-copied") {
+        connector = content_analysis::sdk::DATA_COPIED;
       } else {
         std::cout << "[Demo] Incorrect command line arg: " << arg << std::endl;
         return false;
@@ -133,7 +135,7 @@ void PrintHelp() {
     << "Otherwise the content is read from a file called 'content_or_file'." << std::endl
     << "Multiple [@]content_or_file arguments may be specified, each generates one request." << std::endl
     << std::endl << "Options:"  << std::endl
-    << kArgConnector << "<connector> : one of 'download', 'attach' (default), 'bulk-data-entry', 'print', or 'file-transfer'" << std::endl
+    << kArgConnector << "<connector> : one of 'download', 'attach' (default), 'bulk-data-entry', 'print', 'file-transfer', or 'data-copied'" << std::endl
     << kArgRequestToken << "<unique-token> : defaults to 'req-<number>' which auto increments" << std::endl
     << kArgTag << "<tag> : defaults to 'dlp'" << std::endl
     << kArgThreaded << " : handled multiple requests using threads" << std::endl

--- a/demo/handler.h
+++ b/demo/handler.h
@@ -208,6 +208,9 @@ class Handler : public content_analysis::sdk::AgentEventHandler {
         case content_analysis::sdk::FILE_TRANSFER:
           connector = "file-transfer";
           break;
+        case content_analysis::sdk::DATA_COPIED:
+          connector = "data-copied";
+          break;
         default:
           break;
       }
@@ -239,6 +242,9 @@ class Handler : public content_analysis::sdk::AgentEventHandler {
           break;
         case content_analysis::sdk::ContentAnalysisRequest::SAVE_AS_DOWNLOAD:
           reason = "SAVE_AS_DOWNLOAD";
+          break;
+        case content_analysis::sdk::ContentAnalysisRequest::CLIPBOARD_COPY:
+          reason = "CLIPBOARD_COPY";
           break;
       }
     }


### PR DESCRIPTION
Without the fix, final_size remains 0 during partial chunk reads (ERROR_MORE_DATA).

As a result:
1. Subsequent ReadFile calls write to buffer.data() + 0 (overwriting previously read chunks).
2. The final buffer.resize(final_size) truncates the entire buffer to the size of the last chunk, corrupting the message.

As well as do follow up fixes for adding copied data enum